### PR TITLE
Product updates via sku improvements

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/AddExternalImage.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/AddExternalImage.java
@@ -12,8 +12,6 @@ import javax.annotation.Nullable;
  *
  *  {@doc.gen intro}
  *
- *  {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#addExternalImage()}
- *
  *  <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#addExternalImageByVariantId()}
  *
@@ -41,11 +39,11 @@ public final class AddExternalImage extends UpdateActionImpl<Product> {
         return new AddExternalImage(image, variantId, null);
     }
 
-    public static AddExternalImage ofVariantId(final Image image, final Integer variantId) {
+    public static AddExternalImage ofVariantId(final Integer variantId, final Image image) {
         return new AddExternalImage(image, variantId, null);
     }
 
-    public static AddExternalImage ofSku(final Image image, final String sku) {
+    public static AddExternalImage ofSku(final String sku, final Image image) {
         return new AddExternalImage(image, null, sku);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/AddPrice.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/AddPrice.java
@@ -12,8 +12,6 @@ import javax.annotation.Nullable;
  *
  * {@doc.gen intro}
  *
- * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#addPrice()}
- *
  * <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#addPriceByVariantId()}
  *

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/RemoveImage.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/RemoveImage.java
@@ -13,8 +13,6 @@ import javax.annotation.Nullable;
  *
  * {@doc.gen intro}
  *
- * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#removeImage()}
- *
  * <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#removeImageByVariantId()}
  *
@@ -50,26 +48,26 @@ public final class RemoveImage extends UpdateActionImpl<Product> {
     }
 
     public static RemoveImage of(final Image image, final Integer variantId) {
-        return ofVariantId(image.getUrl(), variantId);
+        return ofVariantId(variantId, image.getUrl());
     }
 
     public static RemoveImage of(final String imageUrl, final Integer variantId) {
-        return ofVariantId(imageUrl, variantId);
+        return ofVariantId(variantId, imageUrl);
     }
 
-    public static RemoveImage ofVariantId(final Image image, final Integer variantId) {
-        return ofVariantId(image.getUrl(), variantId);
+    public static RemoveImage ofVariantId(final Integer variantId, final Image image) {
+        return ofVariantId(variantId, image.getUrl());
     }
 
-    public static RemoveImage ofSku(final Image image, final String sku) {
-        return ofSku(image.getUrl(), sku);
+    public static RemoveImage ofSku(final String sku, final Image image) {
+        return ofSku(sku, image.getUrl());
     }
 
-    public static RemoveImage ofVariantId(final String imageUrl, final Integer variantId) {
+    public static RemoveImage ofVariantId(final Integer variantId, final String imageUrl) {
         return new RemoveImage(imageUrl, variantId, null);
     }
 
-    public static RemoveImage ofSku(final String imageUrl, final String sku) {
+    public static RemoveImage ofSku(final String sku, final String imageUrl) {
         return new RemoveImage(imageUrl, null, sku);
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/RemoveVariant.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/RemoveVariant.java
@@ -11,9 +11,7 @@ import javax.annotation.Nullable;
  *
  * {@doc.gen intro}
  *
- * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#addVariant()}
- *
- * * <p>By variant ID (every variant has a variantId):</p>
+ * <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#removeVariantById()}
  *
  * <p>By SKU (attention, SKU is optional field in a variant):</p>
@@ -55,7 +53,7 @@ public final class RemoveVariant extends UpdateActionImpl<Product> {
         return new RemoveVariant(id, null);
     }
 
-    public static RemoveVariant ofVariantSku(final String sku) {
+    public static RemoveVariant ofSku(final String sku) {
         return new RemoveVariant(null, sku);
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetAttribute.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetAttribute.java
@@ -13,8 +13,6 @@ import javax.annotation.Nullable;
  *
  * {@doc.gen intro}
  *
- * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#setAttribute()}
- *
  * <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#setAttributeByVariantId()}
  *

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetPrices.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetPrices.java
@@ -12,8 +12,6 @@ import java.util.List;
  *
  * {@doc.gen intro}
  *
- * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#setPrices()}
- *
  * <p>By variant ID (every variant has a variantId):</p>
  * {@include.example io.sphere.sdk.products.commands.ProductUpdateCommandIntegrationTest#setPricesByVariantId()}
  *

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
@@ -848,7 +848,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
             final Product productWithVariant = client().executeBlocking(addVariantCommand);
             final ProductVariant variant = productWithVariant.getMasterData().getStaged().getVariants().get(0);
 
-            final Product productWithoutVariant = client().executeBlocking(ProductUpdateCommand.of(productWithVariant, RemoveVariant.ofVariantSku(variant.getSku())));
+            final Product productWithoutVariant = client().executeBlocking(ProductUpdateCommand.of(productWithVariant, RemoveVariant.ofSku(variant.getSku())));
             assertThat(productWithoutVariant.getMasterData().getStaged().getVariants()).isEmpty();
 
             return productWithoutVariant;

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
@@ -435,7 +435,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
             final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofVariantId(MASTER_VARIANT_ID, image)));
             assertThat(productWithImage.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
 
-            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofVariantId(image, MASTER_VARIANT_ID)));
+            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofVariantId(MASTER_VARIANT_ID, image)));
             assertThat(updatedProduct.getMasterData().getStaged().getMasterVariant().getImages()).hasSize(0);
             return updatedProduct;
         });
@@ -449,7 +449,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
             final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofSku(sku, image)));
             assertThat(productWithImage.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
 
-            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofSku(image, sku)));
+            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofSku(sku, image)));
             assertThat(updatedProduct.getMasterData().getStaged().getMasterVariant().getImages()).hasSize(0);
             return updatedProduct;
         });

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
@@ -134,7 +134,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
             assertThat(product.getMasterData().getStaged().getMasterVariant().getImages()).hasSize(0);
 
             final Image image = Image.ofWidthAndHeight("http://www.commercetools.com/assets/img/ct_logo_farbe.gif", 460, 102, "commercetools logo");
-            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofVariantId(image, MASTER_VARIANT_ID)));
+            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofVariantId(MASTER_VARIANT_ID, image)));
 
             assertThat(updatedProduct.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
             return updatedProduct;
@@ -148,7 +148,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
             assertThat(masterVariant.getImages()).hasSize(0);
 
             final Image image = Image.ofWidthAndHeight("http://www.commercetools.com/assets/img/ct_logo_farbe.gif", 460, 102, "commercetools logo");
-            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofSku(image, masterVariant.getSku())));
+            final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofSku(masterVariant.getSku(), image)));
 
             assertThat(updatedProduct.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
             return updatedProduct;
@@ -432,7 +432,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
     public void removeImageByVariantId() throws Exception {
         final Image image = Image.ofWidthAndHeight("http://www.commercetools.com/assets/img/ct_logo_farbe.gif", 460, 102, "commercetools logo");
         withUpdateableProduct(client(), product -> {
-            final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofVariantId(image, MASTER_VARIANT_ID)));
+            final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofVariantId(MASTER_VARIANT_ID, image)));
             assertThat(productWithImage.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
 
             final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofVariantId(image, MASTER_VARIANT_ID)));
@@ -446,7 +446,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
         final Image image = Image.ofWidthAndHeight("http://www.commercetools.com/assets/img/ct_logo_farbe.gif", 460, 102, "commercetools logo");
         withUpdateableProduct(client(), product -> {
             final String sku = product.getMasterData().getStaged().getMasterVariant().getSku();
-            final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofSku(image, sku)));
+            final Product productWithImage = client().executeBlocking(ProductUpdateCommand.of(product, AddExternalImage.ofSku(sku, image)));
             assertThat(productWithImage.getMasterData().getStaged().getMasterVariant().getImages()).isEqualTo(asList(image));
 
             final Product updatedProduct = client().executeBlocking(ProductUpdateCommand.of(productWithImage, RemoveImage.ofSku(image, sku)));


### PR DESCRIPTION
@yanns @ccsalazarr-commercetools please review

I changed some signatures to reduce confusion. So if the name of the method starts with `ofSku` then the first parameter should be the SKU, especially `public static RemoveImage ofSku(final String imageUrl, final String sku)` was counterintuitive.

In the docu I also removed the classic `of` method links since it is better to use only the named `of` methods like `ofSku`.