### PR TITLE
Refactor exists and missing filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,3 @@ notifications:
   email:
     on_success: change
     on_failure: change
-branches:
-  only:
-    - master
-    - generate-query-models

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductAttributeFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductAttributeFilterSearchModel.java
@@ -15,11 +15,11 @@ public final class ProductAttributeFilterSearchModel extends SearchModelImpl<Pro
         super(parent, pathSegment);
     }
 
-    public TermFilterSearchModel<ProductProjection, Boolean> ofBoolean(final String attributeName) {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, Boolean> ofBoolean(final String attributeName) {
         return booleanSearchModel(attributeName).filtered();
     }
 
-    public TermFilterSearchModel<ProductProjection, String> ofString(final String attributeName) {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> ofString(final String attributeName) {
         return stringSearchModel(attributeName).filtered();
     }
 
@@ -59,11 +59,11 @@ public final class ProductAttributeFilterSearchModel extends SearchModelImpl<Pro
         return referenceFilterSearchModel(attributeName);
     }
 
-    public TermFilterSearchModel<ProductProjection, Boolean> ofBooleanSet(final String attributeName) {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, Boolean> ofBooleanSet(final String attributeName) {
         return ofBoolean(attributeName);
     }
 
-    public TermFilterSearchModel<ProductProjection, String> ofStringSet(final String attributeName) {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> ofStringSet(final String attributeName) {
         return ofString(attributeName);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductProjectionFilterSearchModel.java
@@ -23,11 +23,11 @@ public final class ProductProjectionFilterSearchModel extends SearchModelImpl<Pr
         return new ProductVariantFilterSearchModel(this, "variants");
     }
 
-    public TermFilterSearchModel<ProductProjection, String> id() {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> id() {
         return stringSearchModel("id").filtered();
     }
 
-    public TermFilterSearchModel<ProductProjection, String> key() {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> key() {
         return stringSearchModel("key").filtered();
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/search/ProductVariantFilterSearchModel.java
@@ -45,7 +45,7 @@ public final class ProductVariantFilterSearchModel extends SearchModelImpl<Produ
      *
      * @return filters model
      */
-    public TermFilterSearchModel<ProductProjection, Boolean> scopedPriceDiscounted() {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, Boolean> scopedPriceDiscounted() {
         return booleanSearchModel("scopedPriceDiscounted").filtered();
     }
 
@@ -60,11 +60,11 @@ public final class ProductVariantFilterSearchModel extends SearchModelImpl<Produ
      *
      * @return filters model
      */
-    public TermFilterSearchModel<ProductProjection, String> sku() {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> sku() {
         return stringSearchModel("sku").filtered();
     }
 
-    public TermFilterSearchModel<ProductProjection, String> key() {
+    public TermFilterExistsAndMissingSearchModel<ProductProjection, String> key() {
         return stringSearchModel("key").filtered();
     }
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.products.search;
 
+import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
@@ -7,6 +8,7 @@ import io.sphere.sdk.test.IntegrationTest;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -106,6 +108,19 @@ public class ExistsAndMissingFilterIntegrationTest extends IntegrationTest {
                     .build();
             return builder.masterVariant(masterVariant);
         }, m -> m.allVariants().sku());
+    }
+
+    @Test
+    public void nameLocale() {
+        checkFilter(builder -> builder.name(LocalizedString.of(Locale.GERMAN, "foo")),
+                m -> m.name().locale(Locale.GERMAN));
+    }
+
+    @Test
+    public void slugLocale() {
+        final Locale locale = Locale.forLanguageTag("de-AT");
+        checkFilter(builder -> builder.slug(LocalizedString.of(locale, randomKey())),
+                m -> m.slug().locale(locale));
     }
 
     @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/search/ExistsAndMissingFilterIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.sphere.sdk.products.search;
 
-import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.products.*;
 import io.sphere.sdk.products.attributes.AttributeDraft;
 import io.sphere.sdk.search.model.ExistsAndMissingFilterSearchModelSupport;
@@ -8,7 +7,6 @@ import io.sphere.sdk.test.IntegrationTest;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -108,19 +106,6 @@ public class ExistsAndMissingFilterIntegrationTest extends IntegrationTest {
                     .build();
             return builder.masterVariant(masterVariant);
         }, m -> m.allVariants().sku());
-    }
-
-    @Test
-    public void nameLocale() {
-        checkFilter(builder -> builder.name(LocalizedString.of(Locale.GERMAN, "foo")),
-                m -> m.name().locale(Locale.GERMAN));
-    }
-
-    @Test
-    public void slugLocale() {
-        final Locale locale = Locale.forLanguageTag("de-AT");
-        checkFilter(builder -> builder.slug(LocalizedString.of(locale, randomKey())),
-                m -> m.slug().locale(locale));
     }
 
     @Test

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/FilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/FilterSearchModel.java
@@ -9,7 +9,7 @@ import java.util.List;
  * @param <T> type of the resource
  * @param <V> type of the value
  */
-public interface FilterSearchModel<T, V> extends ExistsAndMissingFilterSearchModelSupport<T> {
+public interface FilterSearchModel<T, V> {
 
     /**
      * The search model for the filter.

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedStringFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/LocalizedStringFilterSearchModel.java
@@ -12,7 +12,7 @@ public final class LocalizedStringFilterSearchModel<T> extends SearchModelImpl<T
         super(parent, pathSegment);
     }
 
-    public TermFilterSearchModel<T, String> locale(final Locale locale) {
+    public TermFilterExistsAndMissingSearchModel<T, String> locale(final Locale locale) {
         return new StringSearchModel<>(this, locale.toLanguageTag()).filtered();
     }
 

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
@@ -16,7 +16,7 @@ import static java.util.stream.Collectors.toList;
  * @param <T> type of the resource
  * @param <V> type of the value
  */
-abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSearchModel<T, V> {
+abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSearchModel<T, V>, ExistsAndMissingFilterSearchModelSupport<T> {
     protected final SearchModel<T> searchModel;
     protected final Function<V, String> typeSerializer;
 
@@ -30,12 +30,10 @@ abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSea
         return searchModel;
     }
 
-    @Override
     public List<FilterExpression<T>> exists() {
         return ExistsAndMissingFilterSearchModelSupportUtils.exists(searchModel);
     }
 
-    @Override
     public List<FilterExpression<T>> missing() {
         return ExistsAndMissingFilterSearchModelSupportUtils.missing(searchModel);
     }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterBaseSearchModel.java
@@ -30,10 +30,12 @@ abstract class TermFilterBaseSearchModel<T, V> extends Base implements FilterSea
         return searchModel;
     }
 
+    @Override
     public List<FilterExpression<T>> exists() {
         return ExistsAndMissingFilterSearchModelSupportUtils.exists(searchModel);
     }
 
+    @Override
     public List<FilterExpression<T>> missing() {
         return ExistsAndMissingFilterSearchModelSupportUtils.missing(searchModel);
     }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Model to build term filters with exits and missing predicates
+ * Model to build term filters with exits and missing predicates.
  * .
  * @param <T> type of the resource
  * @param <V> type of the value

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
@@ -1,0 +1,43 @@
+package io.sphere.sdk.search.model;
+
+import io.sphere.sdk.search.FilterExpression;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Model to build term filters.
+ * @param <T> type of the resource
+ * @param <V> type of the value
+ */
+public interface TermFilterExistsAndMissingSearchModel<T, V> extends TermFilterSearchModel<T, V>, ExistsAndMissingFilterSearchModelSupport<T> {
+    @Override
+    List<FilterExpression<T>> containsAll(final Iterable<V> values);
+
+    @Override
+    List<FilterExpression<T>> containsAllAsString(final Iterable<String> values);
+
+    @Override
+    List<FilterExpression<T>> containsAny(final Iterable<V> values);
+
+    @Override
+    List<FilterExpression<T>> containsAnyAsString(final Iterable<String> values);
+
+    @Override
+    List<FilterExpression<T>> is(final V value);
+
+    @Override
+    List<FilterExpression<T>> isIn(final Iterable<V> values);
+
+    /**
+     * Creates an instance of the search model to generate term filters.
+     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param <T> type of the resource
+     * @param <V> type of the value
+     * @return new instance of TermFilterSearchModel
+     */
+    static <T, V> TermFilterExistsAndMissingSearchModel<T, V> of(final String attributePath, final Function<V, String> typeSerializer) {
+        return new TermFilterSearchModelImpl<>(new SearchModelImpl<>(attributePath), typeSerializer);
+    }
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Model to build term filters.
+ * Model to build term filters with exits and missing predicates
+ * .
  * @param <T> type of the resource
  * @param <V> type of the value
  */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModelImpl.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
  * @param <T> type of the resource
  * @param <V> type of the value
  */
-public class TermFilterSearchModelImpl<T, V> extends TermFilterBaseSearchModel<T, V> implements TermFilterSearchModel<T, V> {
+public class TermFilterSearchModelImpl<T, V> extends TermFilterBaseSearchModel<T, V> implements TermFilterExistsAndMissingSearchModel<T, V> {
 
     public TermFilterSearchModelImpl(final SearchModel<T> searchModel, final Function<V, String> typeSerializer) {
         super(searchModel, typeSerializer);

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermModelImpl.java
@@ -12,7 +12,7 @@ abstract class TermModelImpl<T, V> extends SearchModelImpl<T> implements TermMod
     }
 
     @Override
-    public TermFilterSearchModel<T, V> filtered() {
+    public TermFilterExistsAndMissingSearchModel<T, V> filtered() {
         return new TermFilterSearchModelImpl<>(this, typeSerializer);
     }
 


### PR DESCRIPTION
This PR fixes the type hierarchy for the `exists` and `missing` predicates we discussed.