### PR TITLE
#1559: mark masterVariant in ProductDraft and ProductDraftBuilder

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraft.java
@@ -53,6 +53,7 @@ public interface ProductDraft extends WithLocalizedSlug, MetaAttributes {
     @Override
     LocalizedString getMetaKeywords();
 
+    @Nullable
     ProductVariantDraft getMasterVariant();
 
     List<ProductVariantDraft> getVariants();

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
@@ -16,7 +16,7 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 public final class ProductDraftBuilder extends ProductDraftBuilderBase<ProductDraftBuilder> {
 
 
-    ProductDraftBuilder(Set<ResourceIdentifier<Category>> categories, @Nullable CategoryOrderHints categoryOrderHints, @Nullable LocalizedString description, @Nullable String key, @Nullable ProductVariantDraft masterVariant, @Nullable LocalizedString metaDescription, @Nullable LocalizedString metaKeywords, @Nullable LocalizedString metaTitle, LocalizedString name, ResourceIdentifier<ProductType> productType, @Nullable Boolean publish, SearchKeywords searchKeywords, LocalizedString slug, @Nullable Reference<State> state, @Nullable Reference<TaxCategory> taxCategory, List<ProductVariantDraft> variants) {
+    ProductDraftBuilder(final Set<ResourceIdentifier<Category>> categories, @Nullable final CategoryOrderHints categoryOrderHints, @Nullable final LocalizedString description, @Nullable final String key, @Nullable final ProductVariantDraft masterVariant, @Nullable final LocalizedString metaDescription, @Nullable final LocalizedString metaKeywords, @Nullable final LocalizedString metaTitle, final LocalizedString name, final ResourceIdentifier<ProductType> productType, @Nullable final Boolean publish, final SearchKeywords searchKeywords, final LocalizedString slug, @Nullable final Reference<State> state, @Nullable final Reference<TaxCategory> taxCategory, final List<ProductVariantDraft> variants) {
         super(categories, categoryOrderHints, description, key, masterVariant, metaDescription, metaKeywords, metaTitle, name, productType, publish, searchKeywords, slug, state, taxCategory, variants);
         init();
     }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
@@ -16,8 +16,24 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 public final class ProductDraftBuilder extends ProductDraftBuilderBase<ProductDraftBuilder> {
 
 
-    ProductDraftBuilder(final Set<ResourceIdentifier<Category>> categories, @Nullable final CategoryOrderHints categoryOrderHints, @Nullable final LocalizedString description, @Nullable final String key, @Nullable final ProductVariantDraft masterVariant, @Nullable final LocalizedString metaDescription, @Nullable final LocalizedString metaKeywords, @Nullable final LocalizedString metaTitle, final LocalizedString name, final ResourceIdentifier<ProductType> productType, @Nullable final Boolean publish, final SearchKeywords searchKeywords, final LocalizedString slug, @Nullable final Reference<State> state, @Nullable final Reference<TaxCategory> taxCategory, final List<ProductVariantDraft> variants) {
-        super(categories, categoryOrderHints, description, key, masterVariant, metaDescription, metaKeywords, metaTitle, name, productType, publish, searchKeywords, slug, state, taxCategory, variants);
+    ProductDraftBuilder(final Set<ResourceIdentifier<Category>> categories,
+                        @Nullable final CategoryOrderHints categoryOrderHints,
+                        @Nullable final LocalizedString description,
+                        @Nullable final String key,
+                        @Nullable final ProductVariantDraft masterVariant,
+                        @Nullable final LocalizedString metaDescription,
+                        @Nullable final LocalizedString metaKeywords,
+                        @Nullable final LocalizedString metaTitle,
+                        final LocalizedString name,
+                        final ResourceIdentifier<ProductType> productType,
+                        @Nullable final Boolean publish,
+                        final SearchKeywords searchKeywords,
+                        final LocalizedString slug,
+                        @Nullable final Reference<State> state,
+                        @Nullable final Reference<TaxCategory> taxCategory,
+                        final List<ProductVariantDraft> variants) {
+        super(categories, categoryOrderHints, description, key, masterVariant, metaDescription, metaKeywords, metaTitle,
+                name, productType, publish, searchKeywords, slug, state, taxCategory, variants);
         init();
     }
 
@@ -27,14 +43,18 @@ public final class ProductDraftBuilder extends ProductDraftBuilderBase<ProductDr
         searchKeywords = Optional.ofNullable(searchKeywords).orElse(SearchKeywords.of());
     }
 
-    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType, final LocalizedString name, final LocalizedString slug, final List<ProductVariantDraft> allVariants) {
+    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType,
+                                         final LocalizedString name,
+                                         final LocalizedString slug,
+                                         final List<ProductVariantDraft> allVariants) {
         final ProductVariantDraft masterVariant = allVariants.stream().findFirst().orElse(null);
         final List<ProductVariantDraft> variants = allVariants.stream().skip(1).collect(Collectors.toList());
         return of(productType, name, slug, masterVariant)
                 .plusVariants(variants);
     }
 
-    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType, final LocalizedString name,
+    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType,
+                                         final LocalizedString name,
                                          final LocalizedString slug,
                                          @Nullable final ProductVariantDraft masterVariant) {
         return of(productType.toResourceIdentifier(),name,slug,masterVariant);

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraftBuilder.java
@@ -16,7 +16,7 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 public final class ProductDraftBuilder extends ProductDraftBuilderBase<ProductDraftBuilder> {
 
 
-    ProductDraftBuilder(Set<ResourceIdentifier<Category>> categories, @Nullable CategoryOrderHints categoryOrderHints, @Nullable LocalizedString description, @Nullable String key, ProductVariantDraft masterVariant, @Nullable LocalizedString metaDescription, @Nullable LocalizedString metaKeywords, @Nullable LocalizedString metaTitle, LocalizedString name, ResourceIdentifier<ProductType> productType, @Nullable Boolean publish, SearchKeywords searchKeywords, LocalizedString slug, @Nullable Reference<State> state, @Nullable Reference<TaxCategory> taxCategory, List<ProductVariantDraft> variants) {
+    ProductDraftBuilder(Set<ResourceIdentifier<Category>> categories, @Nullable CategoryOrderHints categoryOrderHints, @Nullable LocalizedString description, @Nullable String key, @Nullable ProductVariantDraft masterVariant, @Nullable LocalizedString metaDescription, @Nullable LocalizedString metaKeywords, @Nullable LocalizedString metaTitle, LocalizedString name, ResourceIdentifier<ProductType> productType, @Nullable Boolean publish, SearchKeywords searchKeywords, LocalizedString slug, @Nullable Reference<State> state, @Nullable Reference<TaxCategory> taxCategory, List<ProductVariantDraft> variants) {
         super(categories, categoryOrderHints, description, key, masterVariant, metaDescription, metaKeywords, metaTitle, name, productType, publish, searchKeywords, slug, state, taxCategory, variants);
         init();
     }
@@ -34,7 +34,9 @@ public final class ProductDraftBuilder extends ProductDraftBuilderBase<ProductDr
                 .plusVariants(variants);
     }
 
-    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType, final LocalizedString name, final LocalizedString slug, final ProductVariantDraft masterVariant) {
+    public static ProductDraftBuilder of(final ResourceIdentifiable<ProductType> productType, final LocalizedString name,
+                                         final LocalizedString slug,
+                                         @Nullable final ProductVariantDraft masterVariant) {
         return of(productType.toResourceIdentifier(),name,slug,masterVariant);
     }
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import javax.money.MonetaryAmount;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -251,6 +252,36 @@ public class CartUpdateCommandIntegrationTest extends IntegrationTest {
             final Set<ItemState> state = customLineItem.getState();
             assertThat(state).hasSize(1);
             assertThat(state).extracting("quantity").containsOnly(quantity);
+            assertThat(customLineItem.getTaxCategory()).isEqualTo(taxCategory.toReference());
+
+            final CartQuery cartQuery = CartQuery.of()
+                    .withPredicates(m -> m.customLineItems().slug().is(customLineItem.getSlug())
+                            .and(m.id().is(cart.getId())));
+            assertThat(client().executeBlocking(cartQuery).head().get().getId()).isEqualTo(cart.getId());
+        });
+    }
+
+    @Test
+    public void addMergesSameCustomLineItems() throws Exception {
+        withTaxCategory(client(), taxCategory -> {
+            final Cart cart = createCartWithCountry(client());
+            assertThat(cart.getCustomLineItems()).isEmpty();
+            final MonetaryAmount money = MoneyImpl.of("23.50", EUR);
+            final String slug = "thing-slug";//you handle to identify the custom line item
+            final LocalizedString name = en("thing");
+            final long quantity = 5;
+            final CustomLineItemDraft item = CustomLineItemDraft.of(name, slug, money, taxCategory, quantity, null);
+
+            final Cart cartWith5 = client().executeBlocking(CartUpdateCommand.of(cart, Arrays.asList(AddCustomLineItem.of(item), AddCustomLineItem.of(item))));
+            assertThat(cartWith5.getCustomLineItems()).hasSize(1);
+            final CustomLineItem customLineItem = cartWith5.getCustomLineItems().get(0);
+            assertThat(customLineItem.getMoney()).isEqualTo(money);
+            assertThat(customLineItem.getName()).isEqualTo(name);
+            assertThat(customLineItem.getQuantity()).isEqualTo(quantity * 2);
+            assertThat(customLineItem.getSlug()).isEqualTo(slug);
+            final Set<ItemState> state = customLineItem.getState();
+            assertThat(state).hasSize(1);
+            assertThat(state).extracting("quantity").containsOnly(quantity * 2);
             assertThat(customLineItem.getTaxCategory()).isEqualTo(taxCategory.toReference());
 
             final CartQuery cartQuery = CartQuery.of()


### PR DESCRIPTION
simple PR to solve #1559 :
just add `@Nullable` annotation to `ProductDraft` and `ProductDraftBuilder` since it is supported by platform documenation