### PR TITLE
SSL should be activated in tests when possible

### DIFF
--- a/commercetools-test-lib/src/main/java/io/sphere/sdk/test/IntegrationTest.java
+++ b/commercetools-test-lib/src/main/java/io/sphere/sdk/test/IntegrationTest.java
@@ -124,7 +124,8 @@ public abstract class IntegrationTest {
 
     protected static HttpClient newHttpClient() {
         //NO SSL Client: this client doesn't perform ssl certification check, which is a necessity to run tests on CI
-        return IntegrationTestHttpClient.of(createNoSSLClient());
+        CloseableHttpAsyncClient asyncClient = !"false".equals(System.getenv("JVM_SDK_IT_SSL_VALIDATION")) ? createNoSSLClient() : HttpAsyncClients.createDefault();
+        return IntegrationTestHttpClient.of(asyncClient);
     }
 
     private static CloseableHttpAsyncClient createNoSSLClient() {


### PR DESCRIPTION
SSL is not at all activated due to the fact that CI uses only HTTP, but when possible HTTPS should be reactivated.