### PR TITLE
Evaluate travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ jobs:
     - stage: compile
       script: mvn clean install  javadoc:aggregate -DskipTests
     - stage: staticInspection
-      script:
-        - mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
-        - mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
+      script: mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
+      script: mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
     - stage: test
-      script:
-        - mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
-        - mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
+      script: mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
+      script: mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
 
 #specifiying stages order
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,13 @@ jdk:
   - oraclejdk8
 cache:
   directories:
-  - $HOME
-jobs:
-  include:
-    - stage: compile
-      script: mvn clean install  javadoc:aggregate -DskipTests
-    - stage: staticInspection
-      script: mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
-      script: mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
-    - stage: test
-      script: mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
-      script: mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
-
-#specifiying stages order
-stages:
-  - compile
-  - staticInspection
-  - test
+  - $HOME/.m2
+script: >
+  mvn clean install  javadoc:aggregate -DskipTests
+  && mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
+  && mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
+  && mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
+  && mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
 env:
   global:
   - secure: NtzrTSpGRmHIeK+Ojhv/xrHE+3k2iq36MnS04hwoJJRtlA1sSCs6Wrw+JKWcIfdscPSxqCZy9UkLVUvSm05Qav4mcsDhQ/hdHc7htqT1+mQ1bFs0HdvYUGJsYpL1yV/fd9vZPBKyfbkIPv4+5luYhbGUG5+0mv8PflcO+rCDGH8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ jdk:
   - oraclejdk8
 cache:
   directories:
-  - $HOME/.m2
+  - $HOME
 jobs:
   include:
     - stage: compile
-      script: mvn clean install  javadoc:aggregate -DskipTests -T 20
+      script: mvn clean install  javadoc:aggregate -DskipTests
     - stage: staticInspection
       script:
         - mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 jobs:
   include:
     - stage: compile
-      script: mvn clean install  javadoc:aggregate -DskipTests
+      script: mvn clean install  javadoc:aggregate -DskipTests -T 20
     - stage: staticInspection
       script:
         - mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,24 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-script:
-  - mvn clean install  javadoc:aggregate -DskipTests
-  - mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
-  - mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
-  - mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
-  - mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
+jobs:
+  include:
+    - stage: compile
+      script: mvn clean install  javadoc:aggregate -DskipTests
+    - stage: staticInspection
+      script:
+        - mvn exec:java -pl commercetools-internal-docs -Dexec.mainClass="introspection.rules.RulesMain" -Dexec.classpathScope="test"
+        - mvn exec:java -pl commercetools-models -Dexec.mainClass="io.sphere.sdk.client.MainMethodThreadLeakTest" -Dexec.classpathScope="test"
+    - stage: test
+      script:
+        - mvn test verify -pl commercetools-convenience,commercetools-internal-docs,commercetools-internal-processors,commercetools-java-client-ahc-1_8,commercetools-java-client-ahc-1_9,commercetools-java-client-ahc-2_0
+        - mvn test verify -pl osgi-support/sdk-osgi-test-campaign/ -Dtest=OSGiTestSuite
+
+#specifiying stages order
+stages:
+  - compile
+  - staticInspection
+  - test
 env:
   global:
   - secure: NtzrTSpGRmHIeK+Ojhv/xrHE+3k2iq36MnS04hwoJJRtlA1sSCs6Wrw+JKWcIfdscPSxqCZy9UkLVUvSm05Qav4mcsDhQ/hdHc7htqT1+mQ1bFs0HdvYUGJsYpL1yV/fd9vZPBKyfbkIPv4+5luYhbGUG5+0mv8PflcO+rCDGH8=


### PR DESCRIPTION
by the help of the `&&` directive the commands are executed in chain, and fail once the first command in chain fails. this allows us to avoid also the overhead induced by travis stages.