### PR TITLE
Updating jackson version

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -141,7 +141,8 @@ import java.util.function.Function;
  <li class=change-in-release>added {@link CustomFields} to {@link CustomerGroup}</li>
  <li class=change-in-release>added  {@link io.sphere.sdk.states.StateRole#RETURN}  to {@link io.sphere.sdk.states.StateRole} enumeration</li>
  <li class=change-in-release>added {@link DiscountCode#getGroups()} to {@link DiscountCode}</li>
-<li class=change-in-release>added field deliveryId (referring delivery) to {@link io.sphere.sdk.orders.messages.ParcelItemsUpdatedMessage}</li>
+ <li class=change-in-release>added field deliveryId (referring delivery) to {@link io.sphere.sdk.orders.messages.ParcelItemsUpdatedMessage}</li>
+ <li class=change-in-release>updated jackson version to 2.9.3</li>
  </ul>
 
  <h3 class=released-version id="v1_28_0">1.28.0 (18.01.2018)</h3>

--- a/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/MessageSubscriptionPayload.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/MessageSubscriptionPayload.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.sphere.sdk.annotations.ResourceValue;
 import io.sphere.sdk.messages.Message;
 
 /**
@@ -13,7 +12,6 @@ import io.sphere.sdk.messages.Message;
  * @param <T> the resource type {@link MessageSubscription#getResourceTypeId()}
  */
 @JsonDeserialize(as = MessageSubscriptionPayloadImpl.class)
-@ResourceValue
 public interface MessageSubscriptionPayload<T> extends Payload<T> {
     /**
      * The message payload will always contain the common fields:

--- a/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/MessageSubscriptionPayloadImpl.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/MessageSubscriptionPayloadImpl.java
@@ -1,0 +1,36 @@
+package io.sphere.sdk.subscriptions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.sphere.sdk.messages.Message;
+import io.sphere.sdk.models.Base;
+import io.sphere.sdk.models.Reference;
+
+final class MessageSubscriptionPayloadImpl<T> extends Base implements MessageSubscriptionPayload<T> {
+
+  private Message message;
+
+  private String notificationType;
+
+  private String projectKey;
+
+  private Reference<T> resource;
+
+  @JsonProperty("message")
+  @JsonUnwrapped
+  public Message getMessage() {
+    return message;
+  }
+
+  public String getNotificationType() {
+    return notificationType;
+  }
+
+  public String getProjectKey() {
+    return projectKey;
+  }
+
+  public Reference<T> getResource() {
+    return resource;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <java.major.version>8</java.major.version>
         <java.version>1.${java.major.version}</java.version>
 
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.9.3</jackson.version>
         <gson.version>2.5</gson.version>
         <asynchttpclient18.version>1.8.16</asynchttpclient18.version>
         <asynchttpclient19.version>1.9.33</asynchttpclient19.version>


### PR DESCRIPTION
Updating jackson version,

You might notice that i removed the constructor in `MessageSubscriptionPayloadImpl`, actually this is due to the fact that in the new jackson library you can't use `@JsonUnwrapped` combined with constructor.

closes #1601