### PR TITLE
Make ChannelDraft extend CustomDraft

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
@@ -7,7 +7,6 @@ import io.sphere.sdk.models.Address;
 import io.sphere.sdk.models.GeoJSON;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.WithKey;
-import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.CustomDraft;
 
 import javax.annotation.Nullable;
@@ -25,8 +24,6 @@ import java.util.Set;
 @ResourceDraftValue(
         abstractResourceDraftValueClass = true,
         factoryMethods = @FactoryMethod(parameterNames = {"key"}))
-    String getKey();
-
 public interface ChannelDraft extends WithKey, CustomDraft {
     @Nullable
     Set<ChannelRole> getRoles();
@@ -36,9 +33,6 @@ public interface ChannelDraft extends WithKey, CustomDraft {
 
     @Nullable
     LocalizedString getDescription();
-
-    @Nullable
-    CustomFieldsDraft getCustom();
 
     @Nullable
     Address getAddress();

--- a/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.models.GeoJSON;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.WithKey;
 import io.sphere.sdk.types.CustomFieldsDraft;
+import io.sphere.sdk.types.CustomDraft;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -24,9 +25,9 @@ import java.util.Set;
 @ResourceDraftValue(
         abstractResourceDraftValueClass = true,
         factoryMethods = @FactoryMethod(parameterNames = {"key"}))
-public interface ChannelDraft extends WithKey {
     String getKey();
 
+public interface ChannelDraft extends WithKey, CustomDraft {
     @Nullable
     Set<ChannelRole> getRoles();
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/channels/ChannelDraft.java
@@ -8,6 +8,7 @@ import io.sphere.sdk.models.GeoJSON;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.WithKey;
 import io.sphere.sdk.types.CustomDraft;
+import io.sphere.sdk.types.CustomFieldsDraft;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -25,6 +26,8 @@ import java.util.Set;
         abstractResourceDraftValueClass = true,
         factoryMethods = @FactoryMethod(parameterNames = {"key"}))
 public interface ChannelDraft extends WithKey, CustomDraft {
+    String getKey();
+
     @Nullable
     Set<ChannelRole> getRoles();
 
@@ -33,6 +36,9 @@ public interface ChannelDraft extends WithKey, CustomDraft {
 
     @Nullable
     LocalizedString getDescription();
+
+    @Nullable
+    CustomFieldsDraft getCustom();
 
     @Nullable
     Address getAddress();

--- a/commercetools-models/src/test/java/io/sphere/sdk/channels/ChannelDraftBuilderTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/channels/ChannelDraftBuilderTest.java
@@ -1,13 +1,49 @@
 package io.sphere.sdk.channels;
 
-import io.sphere.sdk.channels.*;
+import io.sphere.sdk.types.CustomFieldsDraft;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChannelDraftBuilderTest {
     @Test
     public void key() {
         assertThat(ChannelDraftBuilder.of("key").build().getKey()).isEqualTo("key");
+    }
+
+    @Test
+    public void custom_withAnyCustomFieldsDraft_ShouldSetCustomFieldsDraftOnBuilder() {
+        final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson("foo", emptyMap());
+
+        final ChannelDraftBuilder channelDraftBuilder = ChannelDraftBuilder.of("key")
+                                                                           .custom(customFieldsDraft);
+
+        assertThat(channelDraftBuilder.getCustom()).isEqualTo(customFieldsDraft);
+    }
+
+    @Test
+    public void custom_withNullCustomFieldsDraft_ShouldSetNullCustomFieldsDraftOnBuilder() {
+        final ChannelDraftBuilder channelDraftBuilder = ChannelDraftBuilder.of("key")
+                                                                           .custom(null);
+
+        assertThat(channelDraftBuilder.getCustom()).isNull();
+    }
+
+    @Test
+    public void of_withNoCustomFieldsDraft_ShouldHaveNullCustomFields() {
+        final ChannelDraftBuilder channelDraftBuilder = ChannelDraftBuilder.of("key");
+
+        assertThat(channelDraftBuilder.getCustom()).isNull();
+    }
+
+    @Test
+    public void build_withAnyCustomFieldsDraft_ShouldBuildChannelDraftWithCustomFields() {
+        final CustomFieldsDraft customFieldsDraft = CustomFieldsDraft.ofTypeIdAndJson("foo", emptyMap());
+        final ChannelDraftBuilder channelDraftBuilder = ChannelDraftBuilder.of("key").custom(customFieldsDraft);
+
+        final ChannelDraft channelDraft = channelDraftBuilder.build();
+
+        assertThat(channelDraft.getCustom()).isEqualTo(customFieldsDraft);
     }
 }


### PR DESCRIPTION
# Description
This PR addresses #1775:
1. Make `ChannelDraft` extend `CustomDraft`. b8fa8e3 | Unit tests were added here: 
5f1f483
2. Boy-scout-change: Remove redundant `getKey()` and `getCustom()` in `ChannelDraft` interface which will be inherited from the super interfaces `WithKey` and `CustomDraft` anyway.

Closes #1775

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
