### PR TITLE
invalid project key should lead to client shutdown

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -148,7 +148,7 @@ import java.util.function.Function;
  <ul>
     <li class=change-in-release>added new fields {@link Payload#getResourceUserProvidedIdentifiers()} and {@link Message#getResourceUserProvidedIdentifiers()} to reference user defined identifiers.</li>
     <li class=change-in-release>added new subscriptions for the following types {@link CartDiscount}, {@link Channel}, {@link DiscountCode}, {@link io.sphere.sdk.extensions.Extension}, {@link ProductDiscount}, {@link ShoppingList}, {@link Subscription}, {@link State}, {@link TaxCategory}, {@link Type}, </li>
-    <li class=fixed-in-release>Now the use of invalid project key leads to client shutdown, instead of tocken fetching retries </li>
+    <li class=fixed-in-release>Now the use of invalid project key leads to client shutdown, instead of token fetching retries </li>
  </ul>
 
  <h3 class=released-version id="v1_35_0">1.35.0 (23.08.2018)</h3>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -148,6 +148,7 @@ import java.util.function.Function;
  <ul>
     <li class=change-in-release>added new fields {@link Payload#getResourceUserProvidedIdentifiers()} and {@link Message#getResourceUserProvidedIdentifiers()} to reference user defined identifiers.</li>
     <li class=change-in-release>added new subscriptions for the following types {@link CartDiscount}, {@link Channel}, {@link DiscountCode}, {@link io.sphere.sdk.extensions.Extension}, {@link ProductDiscount}, {@link ShoppingList}, {@link Subscription}, {@link State}, {@link TaxCategory}, {@link Type}, </li>
+    <li class=fixed-in-release>Now the use of invalid project key leads to client shutdown, instead of tocken fetching retries </li>
  </ul>
 
  <h3 class=released-version id="v1_35_0">1.35.0 (23.08.2018)</h3>

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/ExceptionFactory.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/ExceptionFactory.java
@@ -40,7 +40,11 @@ final class ExceptionFactory {
                 .when(r -> isServiceNotAvailable(r), r -> new ServiceUnavailableException(extractBody(r)))
                 .whenStatus(401, r -> {
                     final String body = extractBody(r);
-                    return body.contains("invalid_token") ? new InvalidTokenException() : new UnauthorizedException(body);
+                    return body.contains("invalid_token") ? new InvalidTokenException() : new UnauthorizedException(body,401);
+                })
+                .whenStatus(400, r -> {
+                    final String body = extractBody(r);
+                    return body.contains("invalid_scope") ? new InvalidTokenException() : new UnauthorizedException(body,400);
                 })
                 .whenStatus(403, r -> new ForbiddenException(extractBody(r)))
                 .whenStatus(500, r -> new InternalServerErrorException(extractBody(r)))

--- a/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
@@ -31,14 +31,13 @@ public class ApacheClientIntegrationTest extends IntegrationTest {
      * This Exception is caused by the fact that the client closes after trying api callback with invalid scope
      * **/
     @Test(expected = IllegalStateException.class )
-    public void testStupidRetries() throws Exception{
+    public void stopRetriesOnInvalidConfig() throws Exception{
         final SphereClientConfig clientConfig = getSphereClientConfig();
         final SphereClientConfig badConfig = SphereClientConfig.of(clientConfig.getProjectKey()+"LL",clientConfig.getClientId(),clientConfig.getClientSecret() ,clientConfig.getAuthUrl() ,clientConfig.getApiUrl()  );
         final HttpClient httpClient = newHttpClient();
         final SphereAccessTokenSupplier tokenSupplier = SphereAccessTokenSupplier.ofAutoRefresh(badConfig, httpClient, false);
         final SphereClient underlying = SphereClient.of(badConfig, httpClient, tokenSupplier);
         BlockingSphereClient localClient = BlockingSphereClient.of(underlying, 30, TimeUnit.SECONDS);
-
         try { assertProjectSettingsAreFine(localClient);} catch (Exception e) {}
         //The sleep op here is added to avoid the race condition (the circuit breaker runs on a diff thread)
         Thread.sleep(100);

--- a/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
@@ -5,17 +5,20 @@ import io.sphere.sdk.http.HttpClient;
 import io.sphere.sdk.projects.Project;
 import io.sphere.sdk.projects.queries.ProjectGet;
 import io.sphere.sdk.test.IntegrationTest;
+import io.sphere.sdk.test.SphereTestUtils;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import static io.sphere.sdk.test.SphereTestUtils.assertEventually;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ApacheClientIntegrationTest extends IntegrationTest {
     @Test
     public void itWorks() throws Exception {
-        //we cannot check this in TeamCity with sphere CI, but with travis
+        //we cannot check this in TeamCity, this test is rather reserved for Travis ci
         if (!"false".equals(System.getenv("JVM_SDK_IT_SSL_VALIDATION"))) {
             final SphereClientConfig config = getSphereClientConfig();
             final HttpClient httpClient = ApacheHttpClientAdapter.of(HttpAsyncClients.createDefault());

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidClientCredentialsException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidClientCredentialsException.java
@@ -7,6 +7,6 @@ public class InvalidClientCredentialsException extends UnauthorizedException {
     private static final long serialVersionUID = 0L;
 
     public InvalidClientCredentialsException(final SphereAuthConfig config) {
-        super("Invalid credentials for " + config.getProjectKey() + " on " + config.getAuthUrl());
+        super("Invalid credentials for " + config.getProjectKey() + " on " + config.getAuthUrl(),401);
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidScopeException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidScopeException.java
@@ -1,0 +1,13 @@
+package io.sphere.sdk.client;
+
+/**
+ * when trying to make a commercetoold eith invalid scope
+ *
+ */
+public class InvalidScopeException extends UnauthorizedException{
+    private static final long serialVersionUID = 0L;
+
+    public InvalidScopeException(final Throwable cause) {
+        super("Invalid scope error",cause,400);
+    }
+}

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidTokenException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidTokenException.java
@@ -7,6 +7,6 @@ public class InvalidTokenException extends UnauthorizedException {
     private static final long serialVersionUID = 0L;
 
     public InvalidTokenException() {
-        super("Invalid token for request.");
+        super("Invalid token for request.",401);
     }
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/UnauthorizedException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/UnauthorizedException.java
@@ -8,11 +8,11 @@ package io.sphere.sdk.client;
 public class UnauthorizedException extends ClientErrorException {
     private static final long serialVersionUID = 0L;
 
-    public UnauthorizedException(final String message) {
-        super(message, 401);
+    public UnauthorizedException(final String message, final int statusCode) {
+        super(message, statusCode);
     }
 
-    public UnauthorizedException(final String message, final Throwable cause) {
-        super(message, cause, 401);
+    public UnauthorizedException(final String message, final Throwable cause, final int statusCode) {
+        super(message, cause, statusCode);
     }
 }

--- a/commercetools-test-lib/src/main/java/io/sphere/sdk/test/IntegrationTest.java
+++ b/commercetools-test-lib/src/main/java/io/sphere/sdk/test/IntegrationTest.java
@@ -88,7 +88,7 @@ public abstract class IntegrationTest {
 //        }
 //    }
 
-    private static void assertProjectSettingsAreFine(final BlockingSphereClient sphereClient) {
+    public static void assertProjectSettingsAreFine(final BlockingSphereClient sphereClient) {
         final JsonNode project = sphereClient.executeBlocking(new SphereRequest<JsonNode>() {
             @Nullable
             @Override


### PR DESCRIPTION
When using an invalid project key, the client does not shutdown which leads to multiple useless retries, tis should be fixed via client shutdown, which prevent further requests.
related to #1817

# Description

Closes #1817 

# Checklist

- [x] Update release Notes
- [x] Add to the current github milestone 
