### PR TITLE
Change date time formatter

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -154,6 +154,7 @@ import java.util.function.Function;
 
  <h3 class=released-version id="v1_40_0">1.40.0</h3>
  <ul>
+    <li class=new-in-release>{@link java.time.ZonedDateTime} formatter now always include milliseconds even if they are equal to 0</li>
     <li class=new-in-release>{@link io.sphere.sdk.customobjects.queries.CustomObjectByIdGet} and {@link CustomObjectByKeyGet} now support expansion parameter</li>
     <li class=change-in-release>{@link io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeOrder} is now deprecated</li>
     <li class=new-in-release>{@link io.sphere.sdk.producttypes.commands.updateactions.ChangeAttributeOrderByName} added</li>

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/ZonedDateTimeSerializer.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/ZonedDateTimeSerializer.java
@@ -8,9 +8,11 @@ import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 
 final class ZonedDateTimeSerializer extends StdScalarSerializer<ZonedDateTime> {
     static final long serialVersionUID = 0L;
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
 
     public ZonedDateTimeSerializer() {
         super(ZonedDateTime.class);
@@ -18,7 +20,8 @@ final class ZonedDateTimeSerializer extends StdScalarSerializer<ZonedDateTime> {
 
     @Override
     public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider arg2) throws IOException {
-        final String res = DateTimeFormatter.ISO_INSTANT.format(value.withZoneSameInstant(ZoneOffset.UTC));
+
+        final String res = FORMATTER.format(value.withZoneSameInstant(ZoneOffset.UTC));
         gen.writeString(res);
     }
 }

--- a/commercetools-sdk-base/src/test/java/io/sphere/sdk/json/SphereJsonUtilsTest.java
+++ b/commercetools-sdk-base/src/test/java/io/sphere/sdk/json/SphereJsonUtilsTest.java
@@ -18,7 +18,7 @@ public class SphereJsonUtilsTest {
         final String timeAsString = "2007-12-03T10:15:30+02:00[Europe/Berlin]";
         final ZonedDateTime dateTime = ZonedDateTime.parse(timeAsString);
         final String actual = SphereJsonUtils.toJsonString(dateTime);
-        assertThat(actual).isEqualTo("\"2007-12-03T09:15:30Z\"");
+        assertThat(actual).isEqualTo("\"2007-12-03T09:15:30.000Z\"");
     }
 
     @Test


### PR DESCRIPTION
# Description

Now the ZonedDateTime formatter should always include milliseconds

# Checklist

- [x] Update release Notes
- [x] Add to the current github milestone 