### PR TITLE
#1918 extend from Custom interfaces for CartDiscount(Draft)

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscount.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscount.java
@@ -9,6 +9,7 @@ import io.sphere.sdk.discountcodes.DiscountCode;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.Resource;
+import io.sphere.sdk.types.Custom;
 import io.sphere.sdk.types.CustomFields;
 
 import javax.annotation.Nullable;
@@ -34,7 +35,7 @@ import java.util.List;
 @HasUpdateCommand
 @HasDeleteCommand(javadocSummary = "Deletes a {@link CartDiscount}.")
 @HasQueryModel
-public interface CartDiscount extends Resource<CartDiscount> {
+public interface CartDiscount extends Resource<CartDiscount>, Custom {
     /**
      * Predicate where the discounts should be applied to.
      *

--- a/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraft.java
@@ -6,6 +6,7 @@ import io.sphere.sdk.annotations.FactoryMethod;
 import io.sphere.sdk.annotations.ResourceDraftValue;
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.types.CustomFieldsDraft;
 
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
@@ -53,7 +54,7 @@ public interface CartDiscountDraft {
      * @return the {@link CustomFields} defined at this {@link CartDiscountDraft}
      */
     @Nullable
-    CustomFields getCustom();
+    CustomFieldsDraft getCustom();
     /**
      * Specify whether the application of this discount causes the following discounts to be ignored.
      * Defaults to {@link StackingMode#STACKING}.

--- a/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraft.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.sphere.sdk.annotations.FactoryMethod;
 import io.sphere.sdk.annotations.ResourceDraftValue;
 import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.types.CustomDraft;
 import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 
@@ -21,7 +22,7 @@ import java.time.ZonedDateTime;
         abstractBuilderClass = true,
         factoryMethods = @FactoryMethod(parameterNames = {"name", "cartPredicate", "value", "target", "sortOrder", "requiresDiscountCode"},
                                         useLowercaseBooleans = true))
-public interface CartDiscountDraft {
+public interface CartDiscountDraft extends CustomDraft {
     String getCartPredicate();
 
     @Nullable

--- a/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraftBuilder.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraftBuilder.java
@@ -2,13 +2,14 @@ package io.sphere.sdk.cartdiscounts;
 
 import io.sphere.sdk.models.LocalizedString;
 import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.types.CustomFieldsDraft;
 
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 
 public final class CartDiscountDraftBuilder extends CartDiscountDraftBuilderBase<CartDiscountDraftBuilder> {
 
-    CartDiscountDraftBuilder(final @Nullable Boolean active, final String cartPredicate, final @Nullable CustomFields custom, final @Nullable LocalizedString description, final LocalizedString name,
+    CartDiscountDraftBuilder(final @Nullable Boolean active, final String cartPredicate, final @Nullable CustomFieldsDraft custom, final @Nullable LocalizedString description, final LocalizedString name,
                              final Boolean requiresDiscountCode, final String sortOrder, final StackingMode stackingMode, final @Nullable CartDiscountTarget target,
                              final @Nullable ZonedDateTime validFrom, final  @Nullable ZonedDateTime validUntil, final CartDiscountValue value) {
         super(active, cartPredicate,custom, description, name, requiresDiscountCode, sortOrder, stackingMode, target, validFrom, validUntil, value);

--- a/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraftDsl.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/cartdiscounts/CartDiscountDraftDsl.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.cartdiscounts;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.sphere.sdk.models.LocalizedString;
-import io.sphere.sdk.types.CustomFields;
+import io.sphere.sdk.types.CustomFieldsDraft;
 
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
@@ -11,7 +11,7 @@ import java.time.ZonedDateTime;
 public final class CartDiscountDraftDsl extends CartDiscountDraftDslBase<CartDiscountDraftDsl> {
 
     @JsonCreator
-    CartDiscountDraftDsl(final @JsonProperty("isActive") @Nullable Boolean active, final String cartPredicate, @Nullable final CustomFields custom, final @Nullable LocalizedString description,
+    CartDiscountDraftDsl(final @JsonProperty("isActive") @Nullable Boolean active, final String cartPredicate, @Nullable final CustomFieldsDraft custom, final @Nullable LocalizedString description,
                          final LocalizedString name, final @JsonProperty("requiresDiscountCode") Boolean requiresDiscountCode,
                          final String sortOrder, final StackingMode stackingMode, final @Nullable CartDiscountTarget target, final @Nullable ZonedDateTime validFrom,
                          final @Nullable ZonedDateTime validUntil, final CartDiscountValue value) {


### PR DESCRIPTION
# Description
We are using a generic utility for calculating custom type update actions, but we are relying on Custom interface on our generic method, so it would be nice to add the Custom interface to CartDiscount and CartDiscountDraft like Category.

[Here](https://github.com/commercetools/commercetools-sync-java/blob/986b6250110654abac2fd68d3f91833c4d4d45ab/src/main/java/com/commercetools/sync/commons/utils/CustomUpdateActionUtils.java#L38-L62
) you can check our use case:

Closes #1918 

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference