### PR TITLE
#1920 add missing factory methods for update actions which takes Reso…

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -157,6 +157,11 @@ import java.util.function.Function;
     <li class=fixed-in-release>Added support for {@link io.sphere.sdk.extensions.AuthorizationHeaderAuthentication} for api extensions.</li>
     <li class=fixed-in-release>Fixed {@link io.sphere.sdk.orderedits.commands.stagedactions.AddLineItem} staged update action structure</li>
     <li class=new-in-release>Added support for {@link io.sphere.sdk.stores.Store}</li>
+    <li class=new-in-release>Added new {@link SetShippingMethod#of(ResourceIdentifier)} method</li>
+    <li class=new-in-release>Added new {@link SetSupplyChannel#of(ResourceIdentifier)} method</li>
+    <li class=new-in-release>Added new {@link SetTaxCategory#of(ResourceIdentifier)} method</li>
+    <li class=new-in-release>Added new {@link RemoveZone#of(ResourceIdentifier)} method</li>
+    <li class=change-in-release>Static 'of' methods that accept {@link Referenceable} got their names changed to 'ofReferencable' and are now deprecated. This was done for the following update actions: {@link SetShippingMethod}, {@link SetSupplyChannel}, {@link SetTaxCategory}, {@link RemoveZone}</li>
  </ul>
 
  <h3 class=released-version id="v1_41_0">1.41.0 (10.04.2019)</h3>

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
@@ -36,9 +36,14 @@ public final class SetShippingMethod extends UpdateActionImpl<Cart> {
                 : ofRemove();
     }
 
+    public static SetShippingMethod of(@Nullable final ResourceIdentifier<ShippingMethod> shippingMethod) {
+        return  new SetShippingMethod(shippingMethod);
+
+    }
+
     public static SetShippingMethod ofId(@Nullable String shippingMethodId) {
         return shippingMethodId != null
-                ? of(ShippingMethod.referenceOfId(shippingMethodId))
+                ? of(ShippingMethod.referenceOfId(shippingMethodId).toResourceIdentifier())
                 : ofRemove();
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
@@ -36,7 +36,7 @@ public final class SetShippingMethod extends UpdateActionImpl<Cart> {
                 : ofRemove();
     }
 
-    public static SetShippingMethod of(@Nullable final ResourceIdentifier<ShippingMethod> shippingMethod) {
+    public static SetShippingMethod of(final ResourceIdentifier<ShippingMethod> shippingMethod) {
         return  new SetShippingMethod(shippingMethod);
 
     }

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethod.java
@@ -2,7 +2,6 @@ package io.sphere.sdk.carts.commands.updateactions;
 
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.commands.UpdateActionImpl;
-import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.Referenceable;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.shippingmethods.ShippingMethod;
@@ -30,15 +29,18 @@ public final class SetShippingMethod extends UpdateActionImpl<Cart> {
         return shippingMethod;
     }
 
-    public static SetShippingMethod of(@Nullable final Referenceable<ShippingMethod> shippingMethod) {
+    /**
+     * This method is deprecated, please use {@link SetShippingMethod#of(ResourceIdentifier)}
+     */
+    @Deprecated
+    public static SetShippingMethod ofReferencable(@Nullable final Referenceable<ShippingMethod> shippingMethod) {
         return shippingMethod != null
                 ? new SetShippingMethod(shippingMethod.toReference())
                 : ofRemove();
     }
 
-    public static SetShippingMethod of(final ResourceIdentifier<ShippingMethod> shippingMethod) {
+    public static SetShippingMethod of(@Nullable final ResourceIdentifier<ShippingMethod> shippingMethod) {
         return  new SetShippingMethod(shippingMethod);
-
     }
 
     public static SetShippingMethod ofId(@Nullable String shippingMethodId) {

--- a/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
@@ -26,14 +26,18 @@ public final class SetSupplyChannel extends UpdateActionImpl<InventoryEntry> {
         this.supplyChannel = supplyChannel;
     }
 
-    public static SetSupplyChannel of(@Nullable final Referenceable<Channel> supplyChannel) {
+    /**
+     * This method is deprecated, please use {@link SetSupplyChannel#of(ResourceIdentifier)}
+     */
+    @Deprecated
+    public static SetSupplyChannel ofReferencable(@Nullable final Referenceable<Channel> supplyChannel) {
         final Reference<Channel> channelReference = Optional.ofNullable(supplyChannel)
                 .map(Referenceable::toReference)
                 .orElse(null);
         return new SetSupplyChannel(channelReference);
     }
 
-    public static SetSupplyChannel of(final ResourceIdentifier<Channel> supplyChannel) {
+    public static SetSupplyChannel of(@Nullable final ResourceIdentifier<Channel> supplyChannel) {
         return new SetSupplyChannel(supplyChannel);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
@@ -33,7 +33,7 @@ public final class SetSupplyChannel extends UpdateActionImpl<InventoryEntry> {
         return new SetSupplyChannel(channelReference);
     }
 
-    public static SetSupplyChannel of(@Nullable final ResourceIdentifier<Channel> supplyChannel) {
+    public static SetSupplyChannel of(final ResourceIdentifier<Channel> supplyChannel) {
         return new SetSupplyChannel(supplyChannel);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/inventory/commands/updateactions/SetSupplyChannel.java
@@ -33,6 +33,10 @@ public final class SetSupplyChannel extends UpdateActionImpl<InventoryEntry> {
         return new SetSupplyChannel(channelReference);
     }
 
+    public static SetSupplyChannel of(@Nullable final ResourceIdentifier<Channel> supplyChannel) {
+        return new SetSupplyChannel(supplyChannel);
+    }
+
     @Nullable
     public ResourceIdentifier<Channel> getSupplyChannel() {
         return supplyChannel;

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
@@ -31,6 +31,10 @@ public final class SetTaxCategory extends UpdateActionImpl<Product> {
         return new SetTaxCategory(Optional.ofNullable(taxCategory).map(Referenceable::toResourceIdentifier).orElse(null));
     }
 
+    public static SetTaxCategory of(@Nullable final ResourceIdentifier<TaxCategory> taxCategory) {
+        return new SetTaxCategory(taxCategory);
+    }
+
     public static SetTaxCategory unset() {
         return new SetTaxCategory(null);
     }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
@@ -31,7 +31,7 @@ public final class SetTaxCategory extends UpdateActionImpl<Product> {
         return new SetTaxCategory(Optional.ofNullable(taxCategory).map(Referenceable::toResourceIdentifier).orElse(null));
     }
 
-    public static SetTaxCategory of(@Nullable final ResourceIdentifier<TaxCategory> taxCategory) {
+    public static SetTaxCategory of(final ResourceIdentifier<TaxCategory> taxCategory) {
         return new SetTaxCategory(taxCategory);
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/commands/updateactions/SetTaxCategory.java
@@ -1,7 +1,6 @@
 package io.sphere.sdk.products.commands.updateactions;
 
 import io.sphere.sdk.commands.UpdateActionImpl;
-import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.Referenceable;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.products.Product;
@@ -27,11 +26,15 @@ public final class SetTaxCategory extends UpdateActionImpl<Product> {
         this.taxCategory = taxCategory;
     }
 
-    public static SetTaxCategory of(@Nullable final Referenceable<TaxCategory> taxCategory) {
+    /**
+     * This method is deprecated, please use {@link SetTaxCategory#of(ResourceIdentifier)}
+     */
+    @Deprecated
+    public static SetTaxCategory ofReferencable(@Nullable final Referenceable<TaxCategory> taxCategory) {
         return new SetTaxCategory(Optional.ofNullable(taxCategory).map(Referenceable::toResourceIdentifier).orElse(null));
     }
 
-    public static SetTaxCategory of(final ResourceIdentifier<TaxCategory> taxCategory) {
+    public static SetTaxCategory of(@Nullable final ResourceIdentifier<TaxCategory> taxCategory) {
         return new SetTaxCategory(taxCategory);
     }
 
@@ -39,8 +42,12 @@ public final class SetTaxCategory extends UpdateActionImpl<Product> {
         return new SetTaxCategory(null);
     }
 
+    /**
+     * This method is deprecated, please use {@link SetTaxCategory#of(ResourceIdentifier)}
+     */
+    @Deprecated
     public static SetTaxCategory to(final Referenceable<TaxCategory> taxCategory) {
-        return of(taxCategory);
+        return ofReferencable(taxCategory);
     }
 
     @Nullable

--- a/commercetools-models/src/main/java/io/sphere/sdk/shippingmethods/commands/updateactions/RemoveZone.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/shippingmethods/commands/updateactions/RemoveZone.java
@@ -1,7 +1,6 @@
 package io.sphere.sdk.shippingmethods.commands.updateactions;
 
 import io.sphere.sdk.commands.UpdateActionImpl;
-import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.Referenceable;
 import io.sphere.sdk.models.ResourceIdentifier;
 import io.sphere.sdk.shippingmethods.ShippingMethod;
@@ -26,7 +25,11 @@ public final class RemoveZone extends UpdateActionImpl<ShippingMethod> {
         return zone;
     }
 
-    public static RemoveZone of(final Referenceable<Zone> zone) {
+    /**
+     * This method is deprecated, please use {@link RemoveZone#of(ResourceIdentifier)}
+     */
+    @Deprecated
+    public static RemoveZone ofReferencable(final Referenceable<Zone> zone) {
         return new RemoveZone(zone.toResourceIdentifier());
     }
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/shippingmethods/commands/updateactions/RemoveZone.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/shippingmethods/commands/updateactions/RemoveZone.java
@@ -29,4 +29,8 @@ public final class RemoveZone extends UpdateActionImpl<ShippingMethod> {
     public static RemoveZone of(final Referenceable<Zone> zone) {
         return new RemoveZone(zone.toResourceIdentifier());
     }
+
+    public static RemoveZone of(final ResourceIdentifier<Zone> zone) {
+        return new RemoveZone(zone);
+    }
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/cartdiscounts/commands/CartDiscountInActualCartIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/cartdiscounts/commands/CartDiscountInActualCartIntegrationTest.java
@@ -117,7 +117,7 @@ public class CartDiscountInActualCartIntegrationTest extends IntegrationTest {
     public void shippingDiscount() {
         withShippingMethodForGermany(client(), shippingMethod -> {
             withCustomerAndFilledCart(client(), (customer, cart) -> {
-                client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod)));
+                client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier())));
                 CartDiscountFixtures.withCartDiscount(client(), builder -> builder
                         .value(RelativeCartDiscountValue.of(10000))
                         .target(ShippingCostTarget.of())
@@ -147,7 +147,7 @@ public class CartDiscountInActualCartIntegrationTest extends IntegrationTest {
         final Long discountedQuantity = 2L;
         withShippingMethodForGermany(client(), shippingMethod -> {
             withCustomerAndFilledCart(client(), (customer, cart) -> {
-                client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod)));
+                client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier())));
                 CartDiscountFixtures.withCartDiscount(client(), builder -> builder
                         .value(RelativeCartDiscountValue.of(10000))
                         .target(MultiBuyLineItemsTarget.of("1 = 1", 3L, discountedQuantity, SelectionMode.CHEAPEST))
@@ -185,7 +185,7 @@ public class CartDiscountInActualCartIntegrationTest extends IntegrationTest {
         withShippingMethodForGermany(client(), shippingMethod -> {
             withCustomer(client(), customer -> {
                 withCartHavingDiscountedCustomLineItem(client(),relativeCartDiscountValue, cart -> {
-                    client().executeBlocking(CartUpdateCommand.of(cart, Arrays.asList(SetShippingAddress.of(Address.of(CountryCode.DE)),SetShippingMethod.of(shippingMethod))));
+                    client().executeBlocking(CartUpdateCommand.of(cart, Arrays.asList(SetShippingAddress.of(Address.of(CountryCode.DE)),SetShippingMethod.of(shippingMethod.toResourceIdentifier()))));
                     withCartDiscount(client(), builder -> builder
                             .value(relativeCartDiscountValue)
                             .target(MultiBuyCustomLineItemsTarget.of("1 = 1", 3L, discountedQuantity, SelectionMode.CHEAPEST))

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/TaxRoundingModeIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/TaxRoundingModeIntegrationTest.java
@@ -193,7 +193,7 @@ public class TaxRoundingModeIntegrationTest extends IntegrationTest {
                     final PriceDraft priceDraft = PriceDraft.of(MoneyImpl.ofCents(centAmount, EUR)).withCountry(DE);
                     final ProductUpdateCommand setPricesCmd = ProductUpdateCommand.of(product, asList(
                             AddPrice.of(MASTER_VARIANT_ID, priceDraft),
-                            SetTaxCategory.of(taxCategory),
+                            SetTaxCategory.of(taxCategory.toResourceIdentifier()),
                             Publish.of()));
                     final Product productWithPrice = client.executeBlocking(setPricesCmd);
                     operator.accept(productWithPrice);

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
@@ -432,7 +432,7 @@ public class CartUpdateCommandIntegrationTest extends IntegrationTest {
                 //add shipping method
                 assertThat(cart.getShippingInfo()).isNull();
                 final CartUpdateCommand updateCommand =
-                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod))
+                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier()))
                                 .plusExpansionPaths(m -> m.shippingInfo().shippingMethod().taxCategory())
                                 .plusExpansionPaths(m -> m.shippingInfo().taxCategory());
                 final Cart cartWithShippingMethod = client().executeBlocking(updateCommand);
@@ -460,7 +460,7 @@ public class CartUpdateCommandIntegrationTest extends IntegrationTest {
         withDynamicShippingMethodForGermany(client(), CartPredicate.of("customer.email=\"john@example.com\""), shippingMethod -> {
             withCart(client(), createCartWithShippingAddress(client()), cart -> {
                 final CartUpdateCommand updateCommand =
-                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod));
+                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier()));
                 assertThatThrownBy(() -> client().executeBlocking(updateCommand)).isInstanceOf(ErrorResponseException.class).hasMessageContaining("does not match");
 
                 return cart;
@@ -668,7 +668,7 @@ public class CartUpdateCommandIntegrationTest extends IntegrationTest {
     public void setShippingMethodTaxAmount() throws Exception {
         withShippingMethodForGermany(client(), shippingMethod -> {
             withCustomLineItemFilledCartWithTaxMode(client(), TaxMode.EXTERNAL_AMOUNT, cart -> {
-                final Cart cartWithShippingMethod = client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod)));
+                final Cart cartWithShippingMethod = client().executeBlocking(CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier())));
                 assertThat(cartWithShippingMethod.getShippingInfo()).isNotNull();
                 assertThat(cartWithShippingMethod.getShippingInfo().getTaxedPrice()).isNull();
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/queries/CartQueryIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/queries/CartQueryIntegrationTest.java
@@ -208,7 +208,7 @@ public class CartQueryIntegrationTest extends IntegrationTest {
         withShippingMethodForGermany(client(), shippingMethod -> {
             withCart(client(), createCartWithShippingAddress(client()), cart -> {
                 final CartUpdateCommand updateCommand =
-                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod))
+                        CartUpdateCommand.of(cart, SetShippingMethod.of(shippingMethod.toResourceIdentifier()))
                                 .plusExpansionPaths(m -> m.shippingInfo().shippingMethod().taxCategory())
                                 .plusExpansionPaths(m -> m.shippingInfo().taxCategory());
                 final Cart cartWithShippingMethod = client().executeBlocking(updateCommand);

--- a/commercetools-models/src/test/java/io/sphere/sdk/inventory/commands/InventoryEntryUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/inventory/commands/InventoryEntryUpdateCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.sphere.sdk.inventory.commands;
 
-import io.sphere.sdk.channels.ChannelFixtures;
 import io.sphere.sdk.channels.ChannelRole;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.inventory.InventoryEntry;
@@ -54,7 +53,7 @@ public class InventoryEntryUpdateCommandIntegrationTest extends IntegrationTest 
     public void setSupplyChannel() throws Exception {
         withChannelOfRole(client(), ChannelRole.INVENTORY_SUPPLY, channel -> {
             withUpdateableInventoryEntry(client(), entry -> {
-                final UpdateAction<InventoryEntry> action = SetSupplyChannel.of(channel);
+                final UpdateAction<InventoryEntry> action = SetSupplyChannel.of(channel.toResourceIdentifier());
                 final InventoryEntry updatedEntry = client().executeBlocking(InventoryEntryUpdateCommand.of(entry, action));
                 assertThat(updatedEntry.getSupplyChannel()).isEqualTo(channel.toReference());
                 return updatedEntry;

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductFixtures.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductFixtures.java
@@ -130,7 +130,7 @@ public class ProductFixtures {
     }
 
     private static ProductUpdateCommand createSetTaxesCommand(final TaxCategory taxCategory, final Product product) {
-        return ProductUpdateCommand.of(product, asList(AddPrice.of(MASTER_VARIANT_ID, PRICE), SetTaxCategory.of(taxCategory), Publish.of()));
+        return ProductUpdateCommand.of(product, asList(AddPrice.of(MASTER_VARIANT_ID, PRICE), SetTaxCategory.of(taxCategory.toResourceIdentifier()), Publish.of()));
     }
 
     public static void withUpdateableProduct(final BlockingSphereClient client, final String testName, final Function<Product, Product> f) {

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductReferenceExpansionIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductReferenceExpansionIntegrationTest.java
@@ -39,7 +39,7 @@ public class ProductReferenceExpansionIntegrationTest extends IntegrationTest {
     public void taxCategory() throws Exception {
         TaxCategoryFixtures.withTransientTaxCategory(client(), taxCategory ->
             withProduct(client(), product -> {
-                final Product productWithTaxCategory = client().executeBlocking(ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory)));
+                final Product productWithTaxCategory = client().executeBlocking(ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory.toResourceIdentifier())));
                 assertThat(productWithTaxCategory.getTaxCategory()).isNotNull();
                 final Query<Product> query = ProductQuery.of().
                         bySlug(ProductProjectionType.CURRENT, Locale.ENGLISH, englishSlugOf(product.getMasterData().getStaged())).

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
@@ -31,7 +31,6 @@ import io.sphere.sdk.suppliers.TShirtProductTypeDraftSupplier.Sizes;
 import io.sphere.sdk.taxcategories.TaxCategoryFixtures;
 import io.sphere.sdk.test.IntegrationTest;
 import io.sphere.sdk.test.SphereTestUtils;
-import io.sphere.sdk.types.CustomFields;
 import io.sphere.sdk.types.CustomFieldsDraft;
 import io.sphere.sdk.types.CustomFieldsDraftBuilder;
 import io.sphere.sdk.types.Type;
@@ -40,7 +39,6 @@ import io.sphere.sdk.utils.MoneyImpl;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.money.MonetaryAmount;
 import java.math.BigDecimal;
 import java.time.ZoneOffset;
@@ -52,7 +50,6 @@ import static io.sphere.sdk.categories.CategoryFixtures.withCategory;
 import static io.sphere.sdk.models.DefaultCurrencyUnits.EUR;
 import static io.sphere.sdk.productdiscounts.ProductDiscountFixtures.withProductDiscount;
 import static io.sphere.sdk.products.ProductFixtures.*;
-import static io.sphere.sdk.products.ProductFixtures.withProductHavingAssets;
 import static io.sphere.sdk.products.ProductProjectionType.STAGED;
 import static io.sphere.sdk.states.StateFixtures.withStateByBuilder;
 import static io.sphere.sdk.states.StateType.PRODUCT_STATE;
@@ -1430,7 +1427,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
         TaxCategoryFixtures.withTransientTaxCategory(client(), taxCategory ->
                 withUpdateableProduct(client(), product -> {
                     assertThat(product.getTaxCategory()).isNotEqualTo(taxCategory);
-                    final ProductUpdateCommand command = ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory));
+                    final ProductUpdateCommand command = ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory.toResourceIdentifier()));
                     final Product updatedProduct = client().executeBlocking(command);
                     assertThat(updatedProduct.getTaxCategory()).isEqualTo(taxCategory.toReference());
                     return updatedProduct;

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/queries/ProductProjectionQueryIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/queries/ProductProjectionQueryIntegrationTest.java
@@ -230,7 +230,7 @@ public class ProductProjectionQueryIntegrationTest extends IntegrationTest {
     public void expandTaxCategory() throws Exception {
         TaxCategoryFixtures.withTransientTaxCategory(client(), taxCategory ->
                         withProduct(client(), product -> {
-                            final Product productWithTaxCategory = client().executeBlocking(ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory)));
+                            final Product productWithTaxCategory = client().executeBlocking(ProductUpdateCommand.of(product, SetTaxCategory.of(taxCategory.toResourceIdentifier())));
                             final ProductProjectionQuery query = ProductProjectionQuery.of(STAGED)
                                     .withPredicates(m -> m.id().is(productWithTaxCategory.getId()))
                                     .withExpansionPaths(m -> m.taxCategory());

--- a/commercetools-models/src/test/java/io/sphere/sdk/shippingmethods/commands/ShippingMethodUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/shippingmethods/commands/ShippingMethodUpdateCommandIntegrationTest.java
@@ -160,7 +160,7 @@ public class ShippingMethodUpdateCommandIntegrationTest extends IntegrationTest 
 
                 //removeZone
                 final ShippingMethod shippingMethodWithoutZone =
-                        client().executeBlocking(ShippingMethodUpdateCommand.of(shippingMethodWithoutShippingRate, RemoveZone.of(zone)));
+                        client().executeBlocking(ShippingMethodUpdateCommand.of(shippingMethodWithoutShippingRate, RemoveZone.of(zone.toResourceIdentifier())));
                 assertThat(shippingMethodWithoutZone.getZoneRates()).isEqualTo(shippingMethod.getZoneRates());
 
                 return shippingMethodWithoutZone;


### PR DESCRIPTION
- add missing factory methods for update actions which take ResourceIdentifier as the parameter.

# Description

an example for this case, according to SetSupplyChannel I need the resource but CTP shows  ResourceIdentifier, not Reference.
https://docs.commercetools.com/http-api-projects-inventory#set-supplychannel 

I have found these 4 update actions which do not have factory methods for `ResourceIdentifier`

Closes #1920

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference