### PR TITLE
1957 Extend WithKey interface in Category, CategoryDraft, ProductLike and ProductDraft.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
   - $HOME/.m2

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -159,7 +159,7 @@ import java.util.function.Function;
  <li class=fixed-in-release>{@link Category}, {@link CategoryDraft}, {@link ProductLike} and {@link ProductDraft} now extend the {@link WithKey} interface.</li>
  </ul>
 
- <h3 class=released-version id="v1_43_0">1.44.0</h3>
+ <h3 class=released-version id="v1_44_0">1.44.0 (07.06.2019)</h3>
  <ul>
     <li class=fixed-in-release>{@link PagedSearchResult#empty()} now creates an instance with the {@link PagedSearchResult#getLimit()} field set to 20, instead of 0</li>
  </ul>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -153,6 +153,11 @@ import java.util.function.Function;
  </ul>
  -->
  -->
+ <!-- TODO: Release date should be added. -->
+ <h3 class=released-version id="v1_44_1">1.45.0 (_DATE_)</h3>
+ <ul>
+ <li class=fixed-in-release>{@link Category}, {@link CategoryDraft}, {@link ProductLike} and {@link ProductDraft} now extend the {@link WithKey} interface.</li>
+ </ul>
 
  <h3 class=released-version id="v1_43_0">1.44.0</h3>
  <ul>

--- a/commercetools-models/src/main/java/io/sphere/sdk/categories/Category.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/categories/Category.java
@@ -62,7 +62,7 @@ import java.util.List;
 @HasUpdateCommand(javadocSummary = "Updates a category.")
 @HasDeleteCommand(javadocSummary = "Deletes a category.", includeExamples = "io.sphere.sdk.categories.commands.CategoryDeleteCommandIntegrationTest#execution()", deleteWith = "key")
 @HasQueryModel(baseInterfaces = {"io.sphere.sdk.queries.QueryModel<io.sphere.sdk.categories.Category>"})
-public interface Category extends Resource<Category>, WithLocalizedSlug, MetaAttributes, Custom {
+public interface Category extends Resource<Category>, WithLocalizedSlug, MetaAttributes, Custom, WithKey {
 
 
     /**
@@ -70,6 +70,7 @@ public interface Category extends Resource<Category>, WithLocalizedSlug, MetaAtt
      *
      * @return the user defined key
      */
+    @Override
     @Nullable
     String getKey();
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/categories/CategoryDraft.java
@@ -21,8 +21,9 @@ import java.util.List;
         abstractBuilderClass = true,
         copyFactoryMethods = @CopyFactoryMethod(Category.class),
         factoryMethods = @FactoryMethod(parameterNames = {"name", "slug"}))
-public interface CategoryDraft extends CustomDraft, WithLocalizedSlug, MetaAttributes {
+public interface CategoryDraft extends CustomDraft, WithLocalizedSlug, MetaAttributes, WithKey {
 
+    @Override
     @Nullable
     String getKey();
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductDraft.java
@@ -27,7 +27,7 @@ import java.util.Set;
         factoryMethods = {@FactoryMethod(parameterNames = {"productType", "name", "slug", "masterVariant"})},
         abstractBuilderClass = true)
 @JsonDeserialize(as = ProductDraftDsl.class)
-public interface ProductDraft extends WithLocalizedSlug, MetaAttributes {
+public interface ProductDraft extends WithLocalizedSlug, MetaAttributes, WithKey {
 
 
     LocalizedString getName();
@@ -80,6 +80,7 @@ public interface ProductDraft extends WithLocalizedSlug, MetaAttributes {
     @JsonProperty("publish")
     Boolean isPublish();
 
+    @Override
     @Nullable
     String getKey();
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/products/ProductLike.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/products/ProductLike.java
@@ -3,6 +3,7 @@ package io.sphere.sdk.products;
 import io.sphere.sdk.commands.UpdateAction;
 import io.sphere.sdk.models.Reference;
 import io.sphere.sdk.models.ResourceView;
+import io.sphere.sdk.models.WithKey;
 import io.sphere.sdk.producttypes.ProductType;
 import io.sphere.sdk.reviews.ReviewRatingStatistics;
 import io.sphere.sdk.states.State;
@@ -11,7 +12,7 @@ import io.sphere.sdk.taxcategories.TaxCategory;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public interface ProductLike<T, O> extends ResourceView<T, O>, ProductIdentifiable {
+public interface ProductLike<T, O> extends ResourceView<T, O>, ProductIdentifiable, WithKey {
     Reference<ProductType> getProductType();
 
     @Nullable
@@ -34,6 +35,7 @@ public interface ProductLike<T, O> extends ResourceView<T, O>, ProductIdentifiab
      * @see io.sphere.sdk.products.commands.ProductUpdateCommand#ofKey(String, Long, List)
      * @see io.sphere.sdk.products.commands.ProductUpdateCommand#ofKey(String, Long, UpdateAction)
      */
+    @Override
     @Nullable
     String getKey();
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
@@ -1,0 +1,27 @@
+package io.sphere.sdk.categories;
+
+import io.sphere.sdk.models.WithKey;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CategoryDraftTest {
+
+    @Test
+    public void categoryDraftImplementsWithKey() {
+        final CategoryDraft category = mock(CategoryDraft.class);
+        when(category.getKey()).thenReturn("foo");
+
+        final String key = getKey(category);
+
+        assertThat(key).isEqualTo(category.getKey());
+    }
+
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+        return resource.getKey();
+    }
+}

--- a/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
@@ -21,7 +21,7 @@ public class CategoryDraftTest {
         assertThat(key).isEqualTo(category.getKey());
     }
 
-    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+    public <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.categories;
 
+import io.sphere.sdk.annotations.NotOSGiCompatible;
 import io.sphere.sdk.models.WithKey;
 import org.junit.Test;
 
@@ -9,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@NotOSGiCompatible
 public class CategoryDraftTest {
 
     @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryDraftTest.java
@@ -23,7 +23,7 @@ public class CategoryDraftTest {
         assertThat(key).isEqualTo(category.getKey());
     }
 
-    public <T extends WithKey> String getKey(@Nonnull final T resource) {
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 }

--- a/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/categories/CategoryTest.java
@@ -2,7 +2,10 @@ package io.sphere.sdk.categories;
 
 import io.sphere.sdk.json.SphereJsonUtils;
 import io.sphere.sdk.models.Reference;
+import io.sphere.sdk.models.WithKey;
 import org.junit.Test;
+
+import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -28,6 +31,19 @@ public class CategoryTest {
                 .contains("name=LocalizedString(de -> Jacken, en -> Jackets, it -> Giacche)")
                 .contains("id=32a65cad-9865-413c-ac7b-aab3c51c63e0")
                 .contains("LocalizedString(de -> meta-title-example)");
+    }
+
+    @Test
+    public void categoryImplementsWithKey() {
+        final Category category = getCategory1();
+
+        final String key = getKey(category);
+
+        assertThat(key).isEqualTo(category.getKey());
+    }
+
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+        return resource.getKey();
     }
 
     private Category getCategory1() {

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
@@ -1,0 +1,28 @@
+package io.sphere.sdk.products;
+
+import io.sphere.sdk.models.WithKey;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProductDraftTest {
+
+    @Test
+    public void productDraftImplementsWithKey() {
+        final ProductDraft productDraft = mock(ProductDraft.class);
+        when(productDraft.getKey()).thenReturn("foo");
+
+        final String key = getKey(productDraft);
+
+        assertThat(key).isEqualTo(productDraft.getKey());
+    }
+
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+        return resource.getKey();
+    }
+
+}

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
@@ -21,7 +21,7 @@ public class ProductDraftTest {
         assertThat(key).isEqualTo(productDraft.getKey());
     }
 
-    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+    public <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.products;
 
+import io.sphere.sdk.annotations.NotOSGiCompatible;
 import io.sphere.sdk.models.WithKey;
 import org.junit.Test;
 
@@ -9,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@NotOSGiCompatible
 public class ProductDraftTest {
 
     @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductDraftTest.java
@@ -23,7 +23,7 @@ public class ProductDraftTest {
         assertThat(key).isEqualTo(productDraft.getKey());
     }
 
-    public <T extends WithKey> String getKey(@Nonnull final T resource) {
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
@@ -1,0 +1,28 @@
+package io.sphere.sdk.products;
+
+import io.sphere.sdk.models.WithKey;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProductLikeTest {
+
+    @Test
+    public void productLikeImplementsWithKey() {
+        final ProductLike productLike = mock(ProductLike.class);
+        when(productLike.getKey()).thenReturn("foo");
+
+        final String key = getKey(productLike);
+
+        assertThat(key).isEqualTo(productLike.getKey());
+    }
+
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+        return resource.getKey();
+    }
+
+}

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
@@ -23,7 +23,7 @@ public class ProductLikeTest {
         assertThat(key).isEqualTo(productLike.getKey());
     }
 
-    public <T extends WithKey> String getKey(@Nonnull final T resource) {
+    private <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.products;
 
+import io.sphere.sdk.annotations.NotOSGiCompatible;
 import io.sphere.sdk.models.WithKey;
 import org.junit.Test;
 
@@ -9,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@NotOSGiCompatible
 public class ProductLikeTest {
 
     @Test

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/ProductLikeTest.java
@@ -21,7 +21,7 @@ public class ProductLikeTest {
         assertThat(key).isEqualTo(productLike.getKey());
     }
 
-    private <T extends WithKey> String getKey(@Nonnull final T resource) {
+    public <T extends WithKey> String getKey(@Nonnull final T resource) {
         return resource.getKey();
     }
 


### PR DESCRIPTION
# Description
- Extends WithKey interface in Category, CategoryDraft, ProductLike and ProductDraft.
Closes #1957 

# Checklist

- [x] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference