### PR TITLE
allow empty array values for customfields

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/types/customupdateactions/SetCustomFieldBase.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/types/customupdateactions/SetCustomFieldBase.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 
 public abstract class SetCustomFieldBase<T> extends UpdateActionImpl<T> {
     private final String name;
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Nullable
     private final JsonNode value;
 


### PR DESCRIPTION
# Description
According to the commercetools platform, API users can set [] as a value for PriceCustomField. But when we use the jvm-sdk, this has been restricted. From jvm-sdk the value is being ignore which leads the platform to remove the attribute. This behaviour is inconsistent compared to commercetools platform, in fact it causes failures for commercetools-sync-java library.

Example scenario:
```
                   "prices": [
                            {
                                "value": {
                                    "type": "centPrecision",
                                    "currencyCode": "EUR",
                                    "centAmount": 4200,
                                    "fractionDigits": 2
                                },
                                "id": "561f7353-1889-4ab3-bf6d-66531745d400",
                                "custom": {
                                    "type": {
                                        "typeId": "type",
                                        "id": "00f62841-7974-4ce5-8727-dc9703596c90"
                                    },
                                    "fields": {
                                        "touchpoints": ["some url"],
                                        "today": "2010-02-02"
                                    }
                                }
                            }
                        ]
```

In above situation, if commercetools-sync-java tries to set value as [] for "touchpoints", it will be completed removed. After that, if commercetools-sync-java wants to update [] value to ["something new"] this would fail from the platform indicating that API user trying to modify a value which is not available. 

Closes #

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference