### PR TITLE
test for allow empty array values for customfields

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -156,7 +156,8 @@ import java.util.function.Function;
 
  <h3 class=released-version id="v1_45_0">1.45.0 (02.08.2019)</h3>
  <ul>
- <li class=fixed-in-release>{@link Category}, {@link CategoryDraft}, {@link ProductLike} and {@link ProductDraft} now extend the {@link WithKey} interface.</li>
+     <li class=fixed-in-release>{@link Category}, {@link CategoryDraft}, {@link ProductLike} and {@link ProductDraft} now extend the {@link WithKey} interface.</li>
+     <li class=fixed-in-release>Update actions for setting custom fields now accept empty array values</li>
  </ul>
 
  <h3 class=released-version id="v1_44_0">1.44.0 (07.06.2019)</h3>

--- a/commercetools-models/src/main/java/io/sphere/sdk/types/customupdateactions/SetCustomFieldBase.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/types/customupdateactions/SetCustomFieldBase.java
@@ -1,6 +1,5 @@
 package io.sphere.sdk.types.customupdateactions;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.commands.UpdateActionImpl;
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/commands/ProductUpdateCommandIntegrationTest.java
@@ -1941,6 +1941,7 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
     public void setProductPriceCustomTypeAndsetProductPriceCustomFieldWithEmptySet() {
         Map<String, JsonNode> map = new HashMap<>();
         ArrayNode arrayNode = new ArrayNode(new JsonNodeFactory(true));
+        arrayNode.add("some value");
         map.put(STRING_SET_FIELD_NAME, arrayNode);
         withUpdateableType(client(), type -> {
             withUpdateablePricedProduct(client(), product -> {
@@ -1952,13 +1953,13 @@ public class ProductUpdateCommandIntegrationTest extends IntegrationTest {
 
                 final Price price = getFirstPrice(updatedProduct);
                 assertThat(price.getCustom().getFieldAsStringSet(STRING_SET_FIELD_NAME))
-                        .isEmpty();
+                        .contains("some value");
 
-                arrayNode.add("a new value");
+                arrayNode.removeAll();
                 final Product updated2 = client().executeBlocking(ProductUpdateCommand.of(updatedProduct,
                         SetProductPriceCustomField.ofObject(STRING_SET_FIELD_NAME, arrayNode, priceId)));
                 assertThat(getFirstPrice(updated2).getCustom().getFieldAsStringSet(STRING_SET_FIELD_NAME))
-                        .contains("a new value");
+                        .isEmpty();
                 return updated2;
             });
             return type;


### PR DESCRIPTION
# Description
Test for allowing empty values for customField attributes. 
Refer to this PR -> https://github.com/commercetools/commercetools-jvm-sdk/pull/1963
Closes #

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference