### PR TITLE
add initial functionality for parametrized queries

### DIFF
--- a/commercetools-models/src/test/java/io/sphere/sdk/products/queries/ProductProjectionQueryIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/products/queries/ProductProjectionQueryIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.sphere.sdk.products.queries;
 
+import io.sphere.sdk.http.NameValuePair;
 import io.sphere.sdk.products.attributes.AttributeAccess;
 import io.sphere.sdk.products.attributes.NamedAttributeAccess;
 import io.sphere.sdk.categories.Category;
@@ -19,6 +20,7 @@ import io.sphere.sdk.queries.QueryPredicate;
 import io.sphere.sdk.taxcategories.TaxCategoryFixtures;
 import io.sphere.sdk.test.IntegrationTest;
 import io.sphere.sdk.utils.MoneyImpl;
+import org.assertj.core.util.Lists;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -140,6 +142,18 @@ public class ProductProjectionQueryIntegrationTest extends IntegrationTest {
     public void queryById() throws Exception {
         with2products("queryById", (p1, p2) -> {
             final Query<ProductProjection> query1 = ProductProjectionQuery.of(STAGED).withPredicates(m -> m.id().isIn(asList(p1.getId(), p2.getId())));
+            assertThat(ids(client().executeBlocking(query1))).containsOnly(p1.getId(), p2.getId());
+
+            final Query<ProductProjection> query = ProductProjectionQuery.of(STAGED).withPredicates(m -> m.id().is(p1.getId()));
+            assertThat(ids(client().executeBlocking(query))).containsOnly(p1.getId());
+        });
+    }
+
+    @Test
+    public void queryByParametrizedId() throws Exception {
+        with2products("queryByParametrizedId", (p1, p2) -> {
+            final Query<ProductProjection> query1 = ProductProjectionQuery.of(STAGED).withPredicates(QueryPredicate.of("id in (:id1, :id2)")).withQueryParam(NameValuePair.of("id1", p1.getId())).withQueryParam(NameValuePair.of("id2", p2.getId()));
+
             assertThat(ids(client().executeBlocking(query1))).containsOnly(p1.getId(), p2.getId());
 
             final Query<ProductProjection> query = ProductProjectionQuery.of(STAGED).withPredicates(m -> m.id().is(p1.getId()));

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/queries/MetaModelQueryDsl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/queries/MetaModelQueryDsl.java
@@ -1,6 +1,7 @@
 package io.sphere.sdk.queries;
 
 import io.sphere.sdk.expansion.MetaModelReferenceExpansionDsl;
+import io.sphere.sdk.http.NameValuePair;
 
 import java.util.List;
 import java.util.function.Function;
@@ -79,4 +80,6 @@ public interface MetaModelQueryDsl<T, C extends MetaModelQueryDsl<T, C, Q, E>, Q
      * @see #withSort(Function)
      */
     C plusSort(final Function<Q, QuerySort<T>> sortFunction);
+
+    C withQueryParam(NameValuePair param);
 }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/queries/MetaModelQueryDslImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/queries/MetaModelQueryDslImpl.java
@@ -15,6 +15,7 @@ import io.sphere.sdk.models.Base;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -218,6 +219,14 @@ public abstract class MetaModelQueryDslImpl<T, C extends MetaModelQueryDsl<T, C,
     @Override
     public C plusExpansionPaths(final Function<E, ExpansionPathContainer<T>> m) {
         return plusExpansionPaths(m.apply(expansionModel).expansionPaths());
+    }
+
+    @Override
+    public C withQueryParam(NameValuePair param) {
+        final List<NameValuePair> params = additionalHttpQueryParameters();
+        final List<NameValuePair> resultingParameters = new LinkedList<>(params);
+        resultingParameters.add(param);
+        return withAdditionalHttpQueryParameters(resultingParameters);
     }
 
     @Override


### PR DESCRIPTION
# Description

The API supports the creation of parametrized queries. This starts by just adding the possibility to add them using string predicates.

It should be discussed how this could be improved for example to have also support in the query predicate builders.

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone 
- [x] Update commercetools api reference