### PR TITLE
ParcelDraft allow setting the parcel items

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
@@ -22,11 +22,19 @@ public interface ParcelDraft {
         return new ParcelDraftDsl(null ,measurements, trackingData);
     }
 
+    static ParcelDraft of(final ParcelMeasurements measurements, final TrackingData trackingData, final List<DeliveryItem> items) {
+        return new ParcelDraftDsl(items ,measurements, trackingData);
+    }
+
     static ParcelDraft of(final ParcelMeasurements measurements) {
         return new ParcelDraftDsl(null, measurements, null);
     }
 
     static ParcelDraft of(final TrackingData trackingData) {
         return new ParcelDraftDsl(null, null, trackingData);
+    }
+
+    static ParcelDraft of(final TrackingData trackingData, final List<DeliveryItem> items) {
+        return new ParcelDraftDsl(items, null, trackingData);
     }
 }


### PR DESCRIPTION
# Description
We want to be able to set the list of delivery items for the parcel.
Right now it is not possible to specify this in the `ParcelDraft` as none of the builder methods accept argument of type  List<DeliveryItem>.

We also tried doing this process in two steps:
First creating delivery for the order
Then updating the order with `AddParcelToDelivery` action
This did not work also because the last argument of type List<DeliveryItem> is ignored and parcel is shown in merchant center always with 0 items.
```
AddParcelToDelivery.of(
             delivery,
             parcel,
             deliveryItems // this is ignored, the items here are not added to the parcel
);
```