### PR TITLE
Added new ParcelDraft 'of' method that accepts a list of DeliveryItems.

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -157,6 +157,7 @@ import java.util.function.Function;
  <h3 class=released-version id="v1_49_0">1.49.0</h3>
  <ul>
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
+    <li class=new-in-release>Added new method {@link ParcelDraft#of(TrackingData, List)}</li>
  </ul>
  
  <h3 class=released-version id="v1_48_0">1.48.0 (16.12.2019)</h3>

--- a/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
@@ -30,7 +30,7 @@ public interface ParcelDraft {
         return new ParcelDraftDsl(null, null, trackingData);
     }
 
-    static ParcelDraft of(final TrackingData trackingData, List<DeliveryItem> deliveryItems) { 
+    static ParcelDraft of(final TrackingData trackingData, final List<DeliveryItem> deliveryItems) { 
         return new ParcelDraftDsl(deliveryItems, null, trackingData); 
     }
 }

--- a/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/orders/ParcelDraft.java
@@ -29,4 +29,8 @@ public interface ParcelDraft {
     static ParcelDraft of(final TrackingData trackingData) {
         return new ParcelDraftDsl(null, null, trackingData);
     }
+
+    static ParcelDraft of(final TrackingData trackingData, List<DeliveryItem> deliveryItems) { 
+        return new ParcelDraftDsl(deliveryItems, null, trackingData); 
+    }
 }


### PR DESCRIPTION
# Description

Closes #1996 

# Checklist

- [x] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference