### PR TITLE
Add correlation id request decorator.

### DIFF
--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecorator.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecorator.java
@@ -1,0 +1,65 @@
+package io.sphere.sdk.client.correlationid;
+
+import io.sphere.sdk.client.HttpRequestIntent;
+import io.sphere.sdk.client.SphereRequest;
+import io.sphere.sdk.client.SphereRequestDecorator;
+import io.sphere.sdk.http.HttpHeaders;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class CorrelationIdRequestDecorator<T> extends SphereRequestDecorator<T> {
+
+    private final String correlationId;
+
+    private CorrelationIdRequestDecorator(@Nonnull final SphereRequest<T> delegate,
+                                          @Nonnull final String correlationId) {
+        super(delegate);
+        this.correlationId = correlationId;
+    }
+
+    /**
+     * Decorates a {@link SphereRequest} as delegate. The main function of decoration is in the
+     * {@link CorrelationIdRequestDecorator#httpRequestIntent()} which stores the supplied {@code correlationId} as a
+     * header in the request with the key {@value HttpHeaders#X_CORRELATION_ID}.
+     *
+     * @param delegate      the delegate {@link SphereRequest} to be decorated.
+     * @param correlationId the correlation id to store in the header of the decorated request.
+     * @param <T>           the type of the resource resulting from performing the request on the commercetools platform.
+     * @return a {@link CorrelationIdRequestDecorator} with a {@link SphereRequest} as delegate. The main function of
+     *         decoration is in the {@link CorrelationIdRequestDecorator#httpRequestIntent()} which stores the supplied
+     *         {@code correlationId} as a header in the request with the key {@value HttpHeaders#X_CORRELATION_ID}.
+     */
+    public static <T> CorrelationIdRequestDecorator<T> of(
+        @Nonnull final SphereRequest<T> delegate,
+        @Nonnull final String correlationId) {
+
+        return new CorrelationIdRequestDecorator<>(delegate, correlationId);
+    }
+
+    @Override
+    public HttpRequestIntent httpRequestIntent() {
+        final HttpRequestIntent httpRequestIntent = super.httpRequestIntent();
+        return httpRequestIntent.plusHeader(HttpHeaders.X_CORRELATION_ID, correlationId);
+    }
+
+    @Override
+    public boolean equals(final Object otherRequest) {
+        if (this == otherRequest) {
+            return true;
+        }
+        if (!(otherRequest instanceof CorrelationIdRequestDecorator)) {
+            return false;
+        }
+        if (!super.equals(otherRequest)) {
+            return false;
+        }
+        final CorrelationIdRequestDecorator<?> that = (CorrelationIdRequestDecorator<?>) otherRequest;
+        return correlationId.equals(that.correlationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), correlationId);
+    }
+}

--- a/commercetools-convenience/src/test/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecoratorTest.java
+++ b/commercetools-convenience/src/test/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecoratorTest.java
@@ -1,0 +1,27 @@
+package io.sphere.sdk.client.correlationid;
+
+import io.sphere.sdk.http.HttpHeaders;
+import io.sphere.sdk.projects.Project;
+import io.sphere.sdk.projects.queries.ProjectGet;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CorrelationIdRequestDecoratorTest {
+
+    @Test
+    public void of_always_ShouldSetCorrelationId() {
+        // prep
+        final String correlationId = UUID.randomUUID().toString();
+        final CorrelationIdRequestDecorator<Project> requestWithCorrelationId = CorrelationIdRequestDecorator
+            .of(ProjectGet.of(), correlationId);
+
+        // test
+        final HttpHeaders headers = requestWithCorrelationId.httpRequestIntent().getHeaders();
+
+        //assert
+        assertThat(headers.getHeader(HttpHeaders.X_CORRELATION_ID)).containsOnly(correlationId);
+    }
+}

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -157,6 +157,7 @@ import java.util.function.Function;
  <h3 class=released-version id="v1_49_0">1.49.0</h3>
  <ul>
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
+    <li class=new-in-release>{@link io.sphere.sdk.client.correlationid.CorrelationIdRequestDecorator} to attach a user-defined correlation id value as a header for the header with key "X-Correlation-ID" on CTP requests.</li>
  </ul>
  
  <h3 class=released-version id="v1_48_0">1.48.0 (16.12.2019)</h3>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -158,7 +158,7 @@ import java.util.function.Function;
  <ul>
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
     <li class=new-in-release>Added new method {@link ParcelDraft#of(TrackingData, List)}</li>
-    <li class=new-in-release>{@link io.sphere.sdk.client.correlationid.CorrelationIdRequestDecorator} to attach a user-defined correlation id value as a header for the header with key "X-Correlation-ID" on CTP requests.</li>
+    <li class=new-in-release>{@link io.sphere.sdk.client.correlationid.CorrelationIdRequestDecorator} to attach a user-defined correlation id as a value for a header with key "X-Correlation-ID" on requests going to the commercetools platform.</li>
  </ul>
  
  <h3 class=released-version id="v1_48_0">1.48.0 (16.12.2019)</h3>


### PR DESCRIPTION
# Description

Often times different services using the JVM SDK need to attach their own correlation id to the requests header going to CTP, treating CTP as an upstream service to this service written using the JVM SDK. 

I thought instead of implementing this decorator class on every service/project that needs it. It would make sense to have it written once and reuse it so (I had this lib https://github.com/heshamMassoud/commercetools-correlation-id-decorator) but then I thought It would make sense to have it in the convenience module of the SDK itself (along with other decorators provided by the SDK: `QueueSphereClientDecorator`, `RetrySphereClientDecorator`, etc..)


# Checklist

- [x] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference