### PR TITLE
fixed generic message deserialization

### DIFF
--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -158,7 +158,7 @@ import java.util.function.Function;
  <h3 class=released-version id="v1_49_0">1.49.0</h3>
  <ul>
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
- <li class=fixed-in-release>fixed {@link io.sphere.sdk.messages.GenericMessageImpl} json deserialization where {@link GenericMessageImpl#getResourceUserProvidedIdentifiers()} was missing </li>
+    <li class=fixed-in-release>fixed {@link io.sphere.sdk.messages.GenericMessageImpl} json deserialization where {@link GenericMessageImpl#getResourceUserProvidedIdentifiers()} was missing </li>
  </ul>
  
  <h3 class=released-version id="v1_48_0">1.48.0 (16.12.2019)</h3>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -61,6 +61,7 @@ import io.sphere.sdk.inventory.InventoryEntryDraft;
 import io.sphere.sdk.inventory.InventoryEntryDraftBuilder;
 import io.sphere.sdk.inventory.commands.updateactions.SetSupplyChannel;
 import io.sphere.sdk.json.SphereJsonUtils;
+import io.sphere.sdk.messages.GenericMessageImpl;
 import io.sphere.sdk.messages.Message;
 import io.sphere.sdk.messages.UserProvidedIdentifiers;
 import io.sphere.sdk.models.*;
@@ -157,6 +158,7 @@ import java.util.function.Function;
  <h3 class=released-version id="v1_49_0">1.49.0</h3>
  <ul>
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
+ <li class=fixed-in-release>fixed {@link io.sphere.sdk.messages.GenericMessageImpl} json deserialization where {@link GenericMessageImpl#getResourceUserProvidedIdentifiers()} was missing </li>
  </ul>
  
  <h3 class=released-version id="v1_48_0">1.48.0 (16.12.2019)</h3>

--- a/commercetools-models/src/main/java/io/sphere/sdk/messages/GenericMessageImpl.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/messages/GenericMessageImpl.java
@@ -44,6 +44,19 @@ public abstract class GenericMessageImpl<R> extends ResourceImpl<Message> implem
         final JavaType javaType = SphereJsonUtils.convertToJavaType(clazz);
         final TypeFactory typeFactory = TypeFactory.defaultInstance();
         this.referenceJavaType = typeFactory.constructParametrizedType(Reference.class, Reference.class, javaType);
+
+        final ObjectMapper objectMapper = SphereJsonUtils.newObjectMapper();
+        JsonNode node = null;
+        
+        if(resourceUserProvidedIdentifiers != null) {
+            node = objectMapper.createObjectNode()
+                    .put("key", resourceUserProvidedIdentifiers.getKey())
+                    .put("externalId", resourceUserProvidedIdentifiers.getExternalId())
+                    .put("orderNumber", resourceUserProvidedIdentifiers.getOrderNumber())
+                    .put("sku", resourceUserProvidedIdentifiers.getSku())
+                    .put("customerNumber", resourceUserProvidedIdentifiers.getCustomerNumber());
+        }
+        this.furtherFields.put("resourceUserProvidedIdentifiers", node);
     }
 
     @Override
@@ -88,6 +101,7 @@ public abstract class GenericMessageImpl<R> extends ResourceImpl<Message> implem
     @Override
     public <T> T as(final Class<T> messageClass) {
         final ObjectMapper objectMapper = SphereJsonUtils.newObjectMapper();
+        
         final ObjectNode jsonNode = objectMapper.createObjectNode()
                 .put("id", getId())
                 .put("version", getVersion())
@@ -96,6 +110,7 @@ public abstract class GenericMessageImpl<R> extends ResourceImpl<Message> implem
                 .put("sequenceNumber", sequenceNumber)
                 .put("resourceVersion", resourceVersion)
                 .put("type", type);
+        
         furtherFields.entrySet().forEach(entry -> jsonNode.replace(entry.getKey(), entry.getValue()));
         jsonNode.replace("resource", resource);
         return SphereJsonUtils.readObject(jsonNode, messageClass);


### PR DESCRIPTION
# Description

Closes #

When: using JsonDeserialize method on Message.class object to convert it into a LineItemStateTransitionMessage.class, e.g. message.as(LineItemStateTransitionMessage.class)

Then: There is null value in the "type" and "resourceUserProvidedIdentifiers" fields

# Checklist

- [x] Update release Notes
- [ ] Add to the current github milestone 
- [ ] Update commercetools api reference