### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
                             <!--<arg>-Xlint:-path</arg>-->
                             <!--<arg>-parameters</arg>-->
                         </compilerArguments>
+                    	<fork>true</fork>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
