### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,14 @@ Note: Integration tests will fail in CI since we use encrypted credentials which
 
 ## Testing
 
-Integration tests should avoid testing the CT Platform, as this is not the focus of the JVM SDK. Nevertheless you need to be aware that the CT Platform will fail silently on certain errors, such as:
+Integration tests should avoid testing the commercetools Composable Commerce API, as this is not the focus of the JVM SDK. Nevertheless you need to be aware that the Composable Commerce API will fail silently on certain errors, such as:
 - wrong field name (unless required)
 - wrong expansion path
 - wrong query predicate
 - wrong sort criteria
 - wrong facet/filter expressions
 
-Therefore you will need to assert that the result provided by the CT Platform is as expected. For example:
+Therefore you will need to assert that the result provided by the Composable Commerce API is as expected. For example:
 ```java
 @Test
 public void testExpansionPath() {

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@ Closes #
 # Checklist
 
 - [ ] Update release Notes
-- [ ] Add to the current github milestone 
-- [ ] Update commercetools api reference
+- [ ] Add to the current github milestone
+- [ ] Update Composable Commerce API reference

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # commercetools JVM SDK
-:warning: **This commercetools JVM SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
+:warning: **This commercetools Composable Commerce JVM SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
 
 | Active Support        | Maintenance Support   | End of Life           |
 | --------------------- | --------------------- | --------------------- |
@@ -14,19 +14,19 @@ We recommend to use our [Java SDK V2](https://docs.commercetools.com/sdk/jvm-sdk
 [![][maven img]][maven]
 [![][license img]][license]
 
-The JVM SDK enables developers to use Java 8 methods and objects to communicate with the [commercetools platform](https://www.commercetools.com/) rather than using plain HTTP calls.
+The JVM SDK enables developers to use Java 8 methods and objects to communicate with the [Composable Commerce API](https://www.commercetools.com/) rather than using plain HTTP calls.
 Users gain type-safety, encapsulation, IDE auto completion and an internal domain specific language to discover and formulate valid requests.
 
 ## JDK compatibility
 Tested with JDKs: Oracle 1.8.0_221, OpenJDK 1.8.0_221 and Amazon Corretto 8.222.10.1.
 
-## Using the SDK 
+## Using the SDK
 * install [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * (since May 19, 2016 new link) [<strong>Javadoc</strong>](https://commercetools.github.io/commercetools-jvm-sdk/apidocs/index.html), there you find also code snippets and insights
     * [Getting Started](https://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/GettingStarted.html)
     * [Release Notes](https://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/ReleaseNotes.html)
     * [Contributing](https://commercetools.github.io/commercetools-jvm-sdk/apidocs/io/sphere/sdk/meta/ContributorDocumentation.html)
- 
+
 ## Installation
 
 ### Java SDK with Maven
@@ -74,7 +74,7 @@ repositories {
 dependencies {
     def jvmSdkVersion = "1.61.0"
     compile "com.commercetools.sdk.jvm.core:commercetools-models:$jvmSdkVersion"
-    compile "com.commercetools.sdk.jvm.core:commercetools-java-client:$jvmSdkVersion"    
+    compile "com.commercetools.sdk.jvm.core:commercetools-java-client:$jvmSdkVersion"
     compile "com.commercetools.sdk.jvm.core:commercetools-convenience:$jvmSdkVersion"
 }
 ````
@@ -101,9 +101,9 @@ Useful code from external developers
 ## Open Source Examples
 * [Sunrise Java](https://github.com/commercetools/commercetools-sunrise-java) - a shop using Play Framework 2.x with Handlebars.java as template engine, Google Guice for DI
 * [Donut](https://github.com/commercetools/commercetools-donut) - single product subscription shop example with Play Framework 2.x and Twirl (Plays default) as template engine
-* [commercetools Spring MVC archetype](https://github.com/commercetools/commercetools-spring-mvc-archetype) - template integrating the SDK with Spring DI and Spring MVC and showing just some products, thymeleaf template engine
+* [Composable Commerce Spring MVC archetype](https://github.com/commercetools/commercetools-spring-mvc-archetype) - template integrating the SDK with Spring DI and Spring MVC and showing just some products, thymeleaf template engine
 * [Reproducer Example](https://github.com/commercetools/commercetools-jvm-sdk-reproducer-example) - a demo which shows how to reproduce errors
- 
+
 ## Stability
 
 1. Experimental features in the API are also experimental features of the SDK.
@@ -125,7 +125,7 @@ Useful code from external developers
 1. set "de", "de-AT", "en" as languages in the Admin Center
 1. set at least one country in the Admin Center
 1. create a file "integrationtest.properties" inside the project root
-1. fill it with the credentials of a new empty commercetools project which is for testing;
+1. fill it with the credentials of a new empty Project which is for testing;
 
 ```
 projectKey=YOUR project key without quotes

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecorator.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/correlationid/CorrelationIdRequestDecorator.java
@@ -25,7 +25,7 @@ public final class CorrelationIdRequestDecorator<T> extends SphereRequestDecorat
      *
      * @param delegate      the delegate {@link SphereRequest} to be decorated.
      * @param correlationId the correlation id to store in the header of the decorated request.
-     * @param <T>           the type of the resource resulting from performing the request on the commercetools platform.
+     * @param <T>           the type of the resource resulting from performing the request on the Composable Commerce APIs.
      * @return a {@link CorrelationIdRequestDecorator} with a {@link SphereRequest} as delegate. The main function of
      *         decoration is in the {@link CorrelationIdRequestDecorator#httpRequestIntent()} which stores the supplied
      *         {@code correlationId} as a header in the request with the key {@value HttpHeaders#X_CORRELATION_ID}.

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClient.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/client/metrics/SimpleMetricsSphereClient.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A decorator for {@link SphereClient}s which collects the time of serialization from and to JSON
- * as well as the time waiting for the response of the commercetools platform.
+ * as well as the time waiting for the response of the Composable Commerce API.
  *
  * {@include.example io.sphere.sdk.client.metrics.SimpleMetricsSphereClientDemo}
  */

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/queries/QueryExecutionUtils.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/queries/QueryExecutionUtils.java
@@ -22,7 +22,7 @@ public final class QueryExecutionUtils {
     /**
      * Queries all elements matching a query by using an offset based pagination with page size {@value DEFAULT_PAGE_SIZE}.
      *
-     * @param client commercetools client
+     * @param client commercetools Composable Commerce client
      * @param query  query containing predicates and expansion paths
      * @param <T>    type of one query result element
      * @param <C>    type of the query
@@ -35,7 +35,7 @@ public final class QueryExecutionUtils {
     /**
      * Queries all elements matching a query by using an offset based pagination.
      *
-     * @param client   commercetools client
+     * @param client   commercetools Composable Commerce client
      * @param query    query containing predicates and expansion paths
      * @param pageSize size of one batch to fetch
      * @param <T>      type of one query result element
@@ -52,7 +52,7 @@ public final class QueryExecutionUtils {
      * page of elements queried. Eventually, the method returns a {@link CompletionStage} that contains a list of all
      * the results of the callbacks returned from every page.
      *
-     * @param client        commercetools client
+     * @param client        commercetools Composable Commerce client
      * @param query         query containing predicates and expansion paths
      * @param resultsMapper callback function that is called on every page queried.
      * @param <T>           type of one query result element
@@ -72,7 +72,7 @@ public final class QueryExecutionUtils {
      * Eventually, the method returns a {@link CompletionStage} that contains a list of all the results of the
      * callbacks returned from every page.
      *
-     * @param client        commercetools client
+     * @param client        commercetools Composable Commerce client
      * @param query         query containing predicates and expansion paths
      * @param resultsMapper callback function that is called on every page queried.
      * @param <T>           type of one query result element
@@ -108,7 +108,7 @@ public final class QueryExecutionUtils {
      * Queries all elements matching a query by using an offset based pagination. The method takes a consumer
      * {@link Consumer} that is applied on on every page of elements queried.
      *
-     * @param client          commercetools client
+     * @param client          commercetools Composable Commerce client
      * @param query           query containing predicates and expansion paths
      * @param resultsConsumer that is applied on every page queried.
      * @param <T>             type of one query result element

--- a/commercetools-convenience/src/main/java/io/sphere/sdk/sequencegenerators/CustomObjectBigIntegerNumberGeneratorConfigBuilder.java
+++ b/commercetools-convenience/src/main/java/io/sphere/sdk/sequencegenerators/CustomObjectBigIntegerNumberGeneratorConfigBuilder.java
@@ -67,7 +67,7 @@ public final class CustomObjectBigIntegerNumberGeneratorConfigBuilder extends Ba
     /**
      * Creates a new builder instance.
      *
-     * @param sphereClient A client to perform requests to the platform.
+     * @param sphereClient A client to perform requests to the Composable Commerce APIs.
      * @param key the key is part of the namespace to store the {@link CustomObject} with the last used sequence number, it normally is sth. like "orderNumber" or "customerNumber"
      * @return the builder instance
      * @see CustomObject

--- a/commercetools-convenience/src/test/java/io/sphere/sdk/meta/CategoryDocumentationIntegrationTest.java
+++ b/commercetools-convenience/src/test/java/io/sphere/sdk/meta/CategoryDocumentationIntegrationTest.java
@@ -433,7 +433,7 @@ public class CategoryDocumentationIntegrationTest extends IntegrationTest {
                                 }
                                 final CategoryDraft draft = categoryDraftBuilder.build();
 
-                                //here is the call to the platform
+                                //here is the call to the Composable Commerce API
                                 final Category category = client().executeBlocking(CategoryCreateCommand.of(draft));
 
                                 externalIdToCategoryMap.put(externalId, category);

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/AsyncDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/AsyncDocumentation.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  If you don't care about threads and asynchronous computation you will probably have a slow and inefficient application.
 
  <p>Suppose you want to show a customer detail page with the cart items and the customer data. For doing this, you need to fetch the cart and the customer.
- Let's suppose fetching those two unrelated documents from the commercetools platform takes 100ms for each document.</p>
+ Let's suppose fetching those two unrelated documents from the commercetools Composable Commerce APIs take 100ms for each document.</p>
 
 
  {@include.example io.sphere.sdk.meta.AsyncDocumentationTest#serialWayToFetchCustomerAndCart()}
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
 
  {@include.example io.sphere.sdk.meta.AsyncDocumentationTest#firstAsyncThenSync()}
 
- Also for a group of commercetools requests they can be executed in parallel and then collected:
+ Also for a group of commercetools Composable Commerce requests, they can be executed in parallel and then collected:
 
  {@include.example io.sphere.sdk.meta.AsyncCollectorDemo}
 

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ConstructionDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ConstructionDocumentation.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.LocalizedString;
 /**
  * This documentation is about creating objects.
  *
- * The commercetools platform saves e-commerce data in the cloud. The JVM SDK is one way to read and write the data.
+ * The commercetools Composable Commerce APIs saves e-commerce data in the cloud. The JVM SDK is one way to read and write the data.
  * There can be other tools like the Merchant Center or product sync tools which can also change data.
  * As a result the data loaded with the JVM SDK is a record of the present or the
  * past since another tool might have changed the data just after loading the data .
@@ -54,8 +54,8 @@ import io.sphere.sdk.models.LocalizedString;
  *  <h3 id=persisting-changes>Persisting Changes</h3>
  *
  *
- *  <p>For persistent changes you need to use a commercetools platform
- *  client and to execute a {@link io.sphere.sdk.commands.Command}. Available commands for the commercetools platform resources
+ *  <p>For persistent changes you need to use the commercetools Composable Commerce system
+ *  client and to execute a {@link io.sphere.sdk.commands.Command}. Available commands for the Composable Commerce API resources
  *  are listed in {@link io.sphere.sdk.meta.SphereResources}</p>
  *
  *  Typically there are three kinds of commands:

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ExceptionDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ExceptionDocumentation.java
@@ -17,7 +17,7 @@ import io.sphere.sdk.models.errors.InvalidJsonInputError;
  *
  * <p>JSON serializing and deserializing problems throw {@link io.sphere.sdk.json.JsonException}.</p>
  *
- * <p>{@link io.sphere.sdk.client.SphereServiceException} is a base exception for all error responses from the commercetools platform (HTTP status code {@code >= 400}).</p>
+ * <p>{@link io.sphere.sdk.client.SphereServiceException} is a base exception for all error responses from the commercetools Composable Commerce APIs (HTTP status code {@code >= 400}).</p>
  *
  * <p>{@link io.sphere.sdk.client.ClientErrorException} expresses errors which can be recovered by the client side (HTTP status code {@code >= 400 and < 500}).
  * {@link io.sphere.sdk.client.ServerErrorException} is for server errors.</p>
@@ -25,7 +25,7 @@ import io.sphere.sdk.models.errors.InvalidJsonInputError;
  * <h3>Errors</h3>
  *
  * If a command cannot be performed due to unfulfilled preconditions
- * the platform can return one error response with multiple errors (<a href="https://docs.commercetools.com/http-api-errors.html">listing of error codes</a>).
+ * the system can return one error response with multiple errors (<a href="https://docs.commercetools.com/http-api-errors.html">listing of error codes</a>).
  * The JVM SDK will then put a {@link io.sphere.sdk.client.ErrorResponseException} into a {@link java.util.concurrent.CompletionStage}.
  *
  * The following example shows how to distinguish errors by error code:

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/GettingStarted.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/GettingStarted.java
@@ -4,7 +4,7 @@ import io.sphere.sdk.models.Base;
 
 /**
  <h3 id=about-clients>About the clients</h3>
- <p>The commercetools platform client communicates asynchronously with the API via HTTPS and it takes care about authentication.</p>
+ <p>The commercetools Composable Commerce client communicates asynchronously with the API via HTTPS and it takes care about authentication.</p>
  <p>The client uses Java objects to formulate an HTTP request, performs the request and maps the JSON response into a Java object.
  The resulting Java object is not directly accessible as object, but it is embedded in a Future/Promise for asynchronous programming.
  Since the client is thread-safe you need only one client to perform multiple requests in parallel.</p>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/GraphQLDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/GraphQLDocumentation.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.meta;
 /**
  * Examples for the usage of GraphQL (experimental).
  *
- * Commercetools GraphQL endpoint to fetch products by sku and only receive id, version and skus:
+ * Composable Commerce GraphQL endpoint to fetch products by sku and only receive id, version and skus:
  *
  * {@include.example io.sphere.sdk.products.LightweightProduct}
  * {@include.example io.sphere.sdk.products.GraphQLIntegrationTest}

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/JvmSdkFeatures.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/JvmSdkFeatures.java
@@ -20,7 +20,7 @@ import io.sphere.sdk.models.Base;
 
 <h3>Domain models are immutable</h3>
 <p>Domain models are no plain old Java objects since the client does not pose control over them, but needs to send
- update commands to commercetools. Thus setters, as provided by <em>other</em> cloud services are not applicable in the platform.</p>
+ update commands to the Composable Commerce HTTP API. Thus setters, as provided by <em>other</em> cloud services are not applicable in the API.</p>
  <p>The approach to synchronize the model in the background blocks the caller thread and makes it hard to impossible to tune error handling, timeouts and recover strategies.
  Our approach makes it explicit, that an operation can be performed in the background, that the operation takes time and that the operation might fail.</p>
 

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ProductAttributeDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ProductAttributeDocumentation.java
@@ -10,7 +10,7 @@ import io.sphere.sdk.products.attributes.AttributeAccess;
  <h3 id="product-type-creation">ProductType Creation</h3>
  <p>A {@link io.sphere.sdk.producttypes.ProductType} is like a schema that defines how the product attributes are structured.</p>
  <p>{@link io.sphere.sdk.producttypes.ProductType}s contain a list of {@link io.sphere.sdk.products.attributes.AttributeDefinition}s which corresponds to the name and type of each attribute, along with some additional information".
- Each name/type pair must be unique across a commercetools project, so if you create an attribute "foo" of type String, you cannot create
+ Each name/type pair must be unique across a Project, so if you create an attribute "foo" of type String, you cannot create
  another {@link io.sphere.sdk.producttypes.ProductType} where "foo" has another type (e.g. {@link LocalizedString}). If you do it anyway you get an error message like:</p>
 
 <pre>"The attribute with name 'foo' has a different type on product type 'exampleproducttype'."</pre>
@@ -115,7 +115,7 @@ import io.sphere.sdk.products.attributes.AttributeAccess;
 
  <h3 id="attribute-table-creation">Creating a table of attributes using {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter}</h3>
 
- <p>The most convenient way of creating a table of attributes is using a subclass of {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter}, since you can rely on defaults and just override the behaviour you want to specify. To initialize the class you need the supported locales of the user viewing the table and the cached {@link io.sphere.sdk.producttypes.ProductType}s of the commercetools project. Remember that you can fetch them all using {@link io.sphere.sdk.queries.QueryExecutionUtils}.</p>
+ <p>The most convenient way of creating a table of attributes is using a subclass of {@link io.sphere.sdk.products.attributes.DefaultProductAttributeFormatter}, since you can rely on defaults and just override the behaviour you want to specify. To initialize the class you need the supported locales of the user viewing the table and the cached {@link io.sphere.sdk.producttypes.ProductType}s of the Project. Remember that you can fetch them all using {@link io.sphere.sdk.queries.QueryExecutionUtils}.</p>
 
  <p>One example for a subclass:</p>
 

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/QueryDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/QueryDocumentation.java
@@ -4,7 +4,7 @@ import io.sphere.sdk.models.Base;
 import io.sphere.sdk.queries.QueryPredicate;
 
 /**
- <p>The Query API is for reading specific resources from the platform.
+ <p>The Query API is for reading specific resources from the system.
  The resources can be sorted and fetched in batches.</p>
 
  <p>First, you need to specify a query, for example:</p>
@@ -15,11 +15,11 @@ import io.sphere.sdk.queries.QueryPredicate;
 
  {@include.example io.sphere.sdk.queries.QueryDemo#executeQuery()}
 
- <p>The successful execution of a {@link io.sphere.sdk.queries.Query} results in {@link io.sphere.sdk.queries.PagedQueryResult} of a platform resource or view.
+ <p>The successful execution of a {@link io.sphere.sdk.queries.Query} results in {@link io.sphere.sdk.queries.PagedQueryResult} of a Composable Commerce resource or view.
  While the {@link io.sphere.sdk.queries.Query} interface just contains information to execute a query,
  the interface {@link io.sphere.sdk.queries.QueryDsl} also provides a domain specific language to tune a query.</p>
 
- <p>For most of the platform resources you can find classes to support you in formulating valid queries (in a sub package queries).</p>
+ <p>For most of the HTTP API resources, you can find classes to support you in formulating valid queries (in a sub package queries).</p>
 
  <p>The following snippet creates a query which selects all products without a specific order.</p>
 
@@ -148,7 +148,7 @@ Like for predicates, you can traverse the query model tree in the same way to sp
 
  <p>Assumption: in a product query all products are sorted by ID by default.</p>
 
- A query might produce more results than you want to consume or the platform lets you consume. At the time of
+ A query might produce more results than you want to consume or the system lets you consume. At the time of
  writing you can only fetch up to 500 objects at once.
 
  <p>Imagine you have 15 products:</p>
@@ -160,7 +160,8 @@ Like for predicates, you can traverse the query model tree in the same way to sp
  {@include.example io.sphere.sdk.meta.QueryDocumentationTest#queryAllExampleInPaginationContext()}
 
  <p>As long as you do not specify a limitation of how many resources should be fetched with one query
- by {@link io.sphere.sdk.queries.QueryDsl#withLimit(Long)}, the platform will deliver up to 20 items so that as a result all (15 products) will be loaded.</p>
+ by {@link io.sphere.sdk.queries.QueryDsl#withLimit(Long)}, the Composable Commerce API will deliver up to 20 items
+ so that as a result all (15 products) will be loaded.</p>
 
  <p>If you specify a limit of 4 to a query as shown below, this query will only load the first 4 products:</p>
  {@include.example io.sphere.sdk.meta.QueryDocumentationTest#limitProductQueryTo4()}

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReferenceExpansionDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReferenceExpansionDocumentation.java
@@ -28,7 +28,7 @@ import io.sphere.sdk.expansion.ReferenceExpansionDsl;
 
  <h3 id=guarantees>Guarantees</h3>
  Reference expansion is a feature without any guarantees. So, if you provide a mal-formatted
- reference expansion path, the platform will not inform you about the problem; but just fulfills the query.
+ reference expansion path, the system will not inform you about the problem; but just fulfills the query.
 
  Even if the expansion path is correct, it is possible that it will not be expanded. This can happen, for example,
  if too many resources are expanded at the same time.

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/ReleaseNotes.java
@@ -327,7 +327,7 @@ import java.util.function.Function;
     <li class=fixed-in-release>{@link TransactionDraftDsl} is now public</li>
     <li class=new-in-release>Added new method {@link ParcelDraft#of(TrackingData, List)}</li>
     <li class=new-in-release>Added support for carts and shopping lists configuration to {@link Project} </li>
-    <li class=new-in-release>{@link io.sphere.sdk.client.correlationid.CorrelationIdRequestDecorator} to attach a user-defined correlation id as a value for a header with key "X-Correlation-ID" on requests going to the commercetools platform.</li>
+    <li class=new-in-release>{@link io.sphere.sdk.client.correlationid.CorrelationIdRequestDecorator} to attach a user-defined correlation id as a value for a header with key "X-Correlation-ID" on requests going to the commercetools Composable Commerce.</li>
     <li class=fixed-in-release>fixed {@link io.sphere.sdk.messages.GenericMessageImpl} json deserialization where {@link GenericMessageImpl#getResourceUserProvidedIdentifiers()} was missing </li>
  </ul>
 
@@ -496,7 +496,7 @@ import java.util.function.Function;
  <li class=change-in-release>update jackson to 2.9.5</li>
  <li class=change-in-release>Update org.asynchttpclient:async-http-client from version 2.0.38 to 2.4.5</li>
  <li class=change-in-release>Changed return type of {@link Cart#getCustomerGroup()} and {@link Customer#getCustomerGroup()} from {@link Reference<CustomerGroup>} to {@link ResourceIdentifier<CustomerGroup>}</li>
- <li class=change-in-release>Add {@link io.sphere.sdk.utils.HighPrecisionMoneyImpl} to enable high precision money in commercetools plateform when needed.</li>
+ <li class=change-in-release>Add {@link io.sphere.sdk.utils.HighPrecisionMoneyImpl} to enable high precision money in Composable Commerce when needed.</li>
  <li class=change-in-release>to enable permanent erasure of users data, a boolean parameter can be set now to specify this in
     {@link io.sphere.sdk.customers.commands.CustomerDeleteCommand},{@link io.sphere.sdk.orders.commands.OrderDeleteCommand}, {@link io.sphere.sdk.carts.commands.CartDeleteCommand}, {@link io.sphere.sdk.payments.commands.PaymentDeleteCommand},
     {@link io.sphere.sdk.shoppinglists.commands.ShoppingListDeleteCommand}, {@link io.sphere.sdk.reviews.commands.ReviewDeleteCommand}, {@link io.sphere.sdk.discountcodes.commands.DiscountCodeDeleteCommand}, {@link CustomObjectDeleteCommand}.
@@ -957,7 +957,7 @@ import java.util.function.Function;
  <li class=change-in-release>The format of the User-Agent header changed to sth. like
  "{@code commercetools-jvm-sdk/1.5.0 (AHC/2.0) Java/1.8.0_101-b13 (Linux; amd64)}" from originally "{@code commercetools JVM SDK 1.4.0}". It is also possible to add a solution info, see {@link io.sphere.sdk.client.SolutionInfo}.</li>
  <li class=change-in-release>Using the default {@link SphereClient} will attempt to fetch a new token if an {@link io.sphere.sdk.client.InvalidTokenException} occurs.</li>
- <li class=change-in-release>{@link LocalizedString#slugified()} and {@link LocalizedString#slugifiedUnique()} generate a String with a max length of 256 to be valid for the commercetools platform. In addition, only allowed characters like {@code [-_a-zA-Z0-9]} will be in the output. Before that it was possible to keep for example a "+".</li>
+ <li class=change-in-release>{@link LocalizedString#slugified()} and {@link LocalizedString#slugifiedUnique()} generate a String with a max length of 256 to be valid for commercetools Composable Commerce. In addition, only allowed characters like {@code [-_a-zA-Z0-9]} will be in the output. Before that it was possible to keep for example a "+".</li>
  </ul>
 
  <h3 class=released-version id="v1_4_0">1.4.0 (29.09.2016)</h3>
@@ -1036,7 +1036,7 @@ import java.util.function.Function;
 
  <h3 class=released-version id="v1_0_0">1.0.0 (03.06.2016)</h3>
  <ul>
- <li class=new-in-release>a new commercetools landing page for the JVM SDK is available at <a href="https://docs.commercetools.com/sdk/jvm-sdk">https://docs.commercetools.com/sdk/jvm-sdk</a></li>
+ <li class=new-in-release>a new Composable Commerce landing page for the JVM SDK is available at <a href="https://docs.commercetools.com/sdk/jvm-sdk">https://docs.commercetools.com/sdk/jvm-sdk</a></li>
  <li class=new-in-release>the GitHub repository has been relocated to <a href="https://github.com/commercetools/commercetools-jvm-sdk">https://github.com/commercetools/commercetools-jvm-sdk</a></li>
  <li class=new-in-release>{@link io.sphere.sdk.client.RetrySphereClientDecorator} to deal with server errors and retry requests</li>
  <li class=new-in-release>{@link ProductProjectionSearch#withFuzzyLevel(java.lang.Integer)} to configure the fuzzy level in the product search</li>
@@ -1345,7 +1345,7 @@ import java.util.function.Function;
  {@include.example io.sphere.sdk.meta.M26Demo#queryCustomObjectsByKeyExample()}
  </div>
  </li>
- <li class=new-in-release>Added {@link Project#getCurrencies()} and {@link Project#getCurrencyUnits()} so you can get your enabled currencies for the commercetools project.</li>
+ <li class=new-in-release>Added {@link Project#getCurrencies()} and {@link Project#getCurrencyUnits()} so you can get your enabled currencies for the Project.</li>
 
  <li class=new-in-release>Added some short hand methods for the work with product attributes like {@link Attribute#getValueAsLong()} and {@link Attribute#getValueAsString()}. For all see {@link Attribute}.</li>
  <li class=new-in-release>Added {@code LocalizedToStringProductAttributeConverter} which provides some defaults to present product attribute (including monetary amounts and date) values as String. The behaviour can be changed through subclasses.</li>
@@ -1360,7 +1360,7 @@ import java.util.function.Function;
  <h3 class=released-version id="v1_0_0_M24">1.0.0-M24 (05.01.2016)</h3>
 
  <ul>
- <li class=new-in-release>Commercetools responses are gzipped which should result in less traffic and faster responses. {@link HttpResponse#getResponseBody()} returns the unpacked body.</li>
+ <li class=new-in-release>Composable Commerce responses are gzipped which should result in less traffic and faster responses. {@link HttpResponse#getResponseBody()} returns the unpacked body.</li>
  <li class=new-in-release>Added {@link io.sphere.sdk.client.BlockingSphereClient} which does not execute asynchronous: {@include.example io.sphere.sdk.meta.BlockingClientValueGetDemo}</li>
  <li class=new-in-release>Added {@link ProductProjectionExpansionModel#allVariants()} for expanding objects in masterVariant and the other variants with one code expression. {@include.example io.sphere.sdk.products.expansion.ProductProjectionExpansionModelTest#allVariants()}</li>
  <li class=new-in-release>{@link io.sphere.sdk.meta.GraphQLDocumentation GraphQL Example}</li>
@@ -1407,7 +1407,7 @@ import java.util.function.Function;
  <li class=change-in-release>Http core: {@link io.sphere.sdk.http.FormUrlEncodedHttpRequestBody} did not respect the order of elements and possible duplicates.
  Use  {@link io.sphere.sdk.http.FormUrlEncodedHttpRequestBody#of(List)} for construction and {@link FormUrlEncodedHttpRequestBody#getParameters()} for getting the data.
  {@code FormUrlEncodedHttpRequestBody#getData()} is deprecated.</li>
- <li class=new-in-release>Added {@link io.sphere.sdk.client.SphereClientConfig#ofProperties(Properties, String)} to get the commercetools credentials form a properties file.</li>
+ <li class=new-in-release>Added {@link io.sphere.sdk.client.SphereClientConfig#ofProperties(Properties, String)} to get the Composable Commerce credentials form a properties file.</li>
  <li class=new-in-release>For SDK contributors: <a href="https://github.com/commercetools/commercetools-jvm-sdk#executing-integration-tests" target="_blank">integration test credentials can be set via a properties file</a></li>
  </ul>
 
@@ -1506,7 +1506,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=change-in-release>Renamed {@code SearchSort} to {@link io.sphere.sdk.search.SortExpression}, which now shares the same properties as {@link io.sphere.sdk.search.FacetExpression} and {@link io.sphere.sdk.search.FilterExpression} under the {@link io.sphere.sdk.search.SearchExpression} interface.</li>
  <li class=change-in-release>The static factory method to directly build unsafe {@link io.sphere.sdk.search.FacetExpression} is now located in {@link io.sphere.sdk.search.TermFacetExpression}, {@link io.sphere.sdk.search.RangeFacetExpression} and {@link io.sphere.sdk.search.FilteredFacetExpression}, so that a facet expression for the corresponding type is obtained.</li>
  <li class=change-in-release>Moved related Search Model classes from {@code io.sphere.sdk.search} to {@code io.sphere.sdk.search.model} package, to clearly separate the Search Model from the Search API classes.</li>
- <li class=removed-in-release>Removed type parameters from {@link io.sphere.sdk.search.TermFacetResult}, {@link io.sphere.sdk.search.RangeFacetResult} and {@link io.sphere.sdk.search.FilteredFacetResult}, which now return simple strings as they are received from the platform.</li>
+ <li class=removed-in-release>Removed type parameters from {@link io.sphere.sdk.search.TermFacetResult}, {@link io.sphere.sdk.search.RangeFacetResult} and {@link io.sphere.sdk.search.FilteredFacetResult}, which now return simple strings as they are received from Composable Commerce.</li>
  <li class=new-in-release>Added {@link ProductProjection#getCategoryOrderHints()} and {@link ProductProjectionQueryModel#categoryOrderHints()}. It can be used for search as shown in the following example, but the meta model comes in a later release.
  <div class="rn-hidden">{@include.example io.sphere.sdk.products.ProductCategoryOrderHintIntegrationTest#searchForCategoryAndSort()}</div>
  </li>
@@ -1601,7 +1601,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=new-in-release>Added documentation how to query for large offsets in {@link QueryDocumentation}.</li>
  <li class=new-in-release>Added hints how to format date and monetary data in {@link FormattingDocumentation}.</li>
  <li class=new-in-release>Added {@link io.sphere.sdk.producttypes.commands.ProductTypeUpdateCommand}.</li>
- <li class=new-in-release>To imrove the query speed the calculation of the total amount of items in commercetools platform can be deactivated with {@link io.sphere.sdk.products.queries.ProductQuery#withFetchTotal(boolean)}.</li>
+ <li class=new-in-release>To improve the query speed the calculation of the total amount of items in commercetools Composable Commerce can be deactivated with {@link io.sphere.sdk.products.queries.ProductQuery#withFetchTotal(boolean)}.</li>
  <li class=new-in-release>{@link QueryPredicate}s can be negated with {@link QueryPredicate#negate()}</li>
  <li class=new-in-release>Added {@link io.sphere.sdk.carts.CartState#ORDERED} and {@link Order#getCart()}.</li>
  <li class=new-in-release>Added {@code io.sphere.sdk.products.ProductProjection#findVariantBySky(String)}.</li>
@@ -1612,7 +1612,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=change-in-release>The instantiation of the {@link io.sphere.sdk.client.SphereClient} has been changed, see {@link GettingStarted} and {@link io.sphere.sdk.client.SphereClientFactory}.</li>
  <li class=change-in-release>Product type creation has been refactored. Have a look at {@link ProductAttributeDocumentation product attribute tutorial}.</li>
  <li class=change-in-release>Product prices have an ID and price updates need to be performed via the price ID: {@link io.sphere.sdk.products.commands.updateactions.ChangePrice}, {@link io.sphere.sdk.products.commands.updateactions.RemovePrice}. Keep in mind that {@code io.sphere.sdk.products.Price#equals(Object)} includes the ID.</li>
- <li class=change-in-release>The naming conventions in the commercetools platform have been changed:
+ <li class=change-in-release>The naming conventions in Composable Commerce have been changed:
  <ul>
  <li>PlainEnumValue is now EnumValue</li>
  <li>LocalizedStrings is now LocalizedString</li>
@@ -1621,7 +1621,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  </ul>
  </li>
 
- <li class=change-in-release>{@code JsonUtils} have been renamed to {@link io.sphere.sdk.json.SphereJsonUtils}, this is an internal utility class working for the commercetools platform context, it is not intended to build apps or libs on it.</li>
+ <li class=change-in-release>{@code JsonUtils} have been renamed to {@link io.sphere.sdk.json.SphereJsonUtils}, this is an internal utility class working for commercetools Composable Commerce context, it is not intended to build apps or libs on it.</li>
  <li class=change-in-release>{@code ChannelRoles} have been renamed to {@link io.sphere.sdk.channels.ChannelRole}.</li>
  <li class=change-in-release>{@code SearchText} is now {@link io.sphere.sdk.models.LocalizedStringEntry}</li>
  <li class=removed-in-release>Removed {@code ProductUpdateScope}, so all product update actions update only staged.</li>
@@ -1676,7 +1676,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=new-in-release>{@link io.sphere.sdk.client.SphereClientConfig#ofEnvironmentVariables(String)} to get the </li>
  <li class=change-in-release>The product attributes have been refactored, look at the {@link ProductAttributeDocumentation} how it works now.</li>
  <li class=change-in-release>{@link io.sphere.sdk.client.SphereClient} implements {@link AutoCloseable} instead of {@link java.io.Closeable}.</li>
- <li class=change-in-release>For timestamps we moved from {@link java.time.Instant} to {@link java.time.ZonedDateTime} since the latter also contains a timezone which better reflects the platforms date time data.</li>
+ <li class=change-in-release>For timestamps we moved from {@link java.time.Instant} to {@link java.time.ZonedDateTime} since the latter also contains a timezone which better reflects Composable Commerce's date time data.</li>
  <li class=change-in-release>Getting the child categories of a category is not in category anymore but in {@link CategoryTree#findChildren(Identifiable)}.</li>
  <li class=fixed-in-release>Sphere client does not shutdown actors properly.  See <a target="_blank" href="https://github.com/commercetools/commercetools-jvm-sdk/issues/491">#491</a>.</li>
  <li class=removed-in-release>{@code Category#getPathInTree()}</li>
@@ -1689,11 +1689,11 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <h3 class=released-version id=v1_0_0_M14>1.0.0-M14 (27.05.2015)</h3>
  <ul>
  <li class=new-in-release>New fields in {@link io.sphere.sdk.products.Price}: {@link Price#getValidFrom()} and {@link Price#getValidUntil()}.</li>
- <li class=new-in-release>Use {@link io.sphere.sdk.products.queries.ProductProjectionQueryModel#allVariants()} to formulate a predicate for all variants. In the platform the json fields masterVariant (object) and variants (array of objects) together contain all variants.</li>
+ <li class=new-in-release>Use {@link io.sphere.sdk.products.queries.ProductProjectionQueryModel#allVariants()} to formulate a predicate for all variants. In Composable Commerce, the json fields masterVariant (object) and variants (array of objects) together contain all variants.</li>
  <li class=new-in-release>Using {@link ProductProjectionQuery#ofCurrent()} and {@link ProductProjectionQuery#ofStaged()} saves you the import of {@link ProductProjectionType}.</li>
- <li class=new-in-release>{@link CompletionStage} does not support by default timeouts which are quite important in a reactive application so you can decorate the {@link io.sphere.sdk.client.SphereClient} with {@link io.sphere.sdk.client.TimeoutSphereClientDecorator} to get a {@link java.util.concurrent.TimeoutException} after a certain amount of time. But this does NOT cancel the request to the platform.</li>
+ <li class=new-in-release>{@link CompletionStage} does not support by default timeouts which are quite important in a reactive application so you can decorate the {@link io.sphere.sdk.client.SphereClient} with {@link io.sphere.sdk.client.TimeoutSphereClientDecorator} to get a {@link java.util.concurrent.TimeoutException} after a certain amount of time. But this does NOT cancel the request to Composable Commerce.</li>
  <li class=new-in-release>The {@code io.sphere.sdk.reviews.Review} endpoints and models are implemented, but we suggest to not use it, since {@code io.sphere.sdk.reviews.Review}s cannot be deleted or marked as hidden.</li>
- <li class=new-in-release>New endpoint: Use {@link io.sphere.sdk.projects.queries.ProjectGet} to get the currencies, countries and languages of the commercetools project.</li>
+ <li class=new-in-release>New endpoint: Use {@link io.sphere.sdk.projects.queries.ProjectGet} to get the currencies, countries and languages of the Project.</li>
  <li class=new-in-release>Categories with SEO meta attributes {@link Category#getMetaTitle()}, {@link Category#getMetaDescription()} and {@link Category#getMetaKeywords()} and
  update actions {@link io.sphere.sdk.categories.commands.updateactions.SetMetaTitle}, {@link io.sphere.sdk.categories.commands.updateactions.SetMetaDescription} and {@link io.sphere.sdk.categories.commands.updateactions.SetMetaKeywords}.</li>
  <li class=new-in-release>Cart discounts: {@link io.sphere.sdk.cartdiscounts.commands.CartDiscountCreateCommand}.</li>
@@ -1704,7 +1704,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=change-in-release>Sort related classes for the Query API have been renamed with a "Query" prefix, to distinguish them from the Search API sort classes.</li>
  <li class=change-in-release>{@code io.sphere.sdk.queries.Predicate} has been renamed to {@link io.sphere.sdk.queries.QueryPredicate}.</li>
  <li class=change-in-release>The JVM SDK itself uses for tests the <a href="https://joel-costigliola.github.io/assertj/">assertj</a> assertion methods instead of fest assertions.</li>
- <li class=change-in-release>{@code io.sphere.sdk.products.commands.updateactions.SetMetaAttributes} has been removed since it is deprecated in the commercetools platform.
+ <li class=change-in-release>{@code io.sphere.sdk.products.commands.updateactions.SetMetaAttributes} has been removed since it is deprecated in Composable Commerce.
  Use {@link SetMetaTitle},
  {@link SetMetaDescription},
  {@link SetMetaKeywords} or {@link io.sphere.sdk.products.commands.updateactions.MetaAttributesUpdateActions} for all together.
@@ -1756,7 +1756,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <ul>
  <li class=new-in-release>Added the {@link io.sphere.sdk.orders.commands.OrderImportCommand}.</li>
  <li class=new-in-release>Added the nested attributes: {@code io.sphere.sdk.attributes.AttributeAccess#ofNested()} + {@code io.sphere.sdk.attributes.AttributeAccess#ofNestedSet()}.</li>
- <li class=new-in-release>The error JSON body from the platform responses can be directly extracted as JSON with {@link io.sphere.sdk.client.SphereServiceException#getJsonBody()}.</li>
+ <li class=new-in-release>The error JSON body from Composable Commerce responses can be directly extracted as JSON with {@link io.sphere.sdk.client.SphereServiceException#getJsonBody()}.</li>
  <li class=new-in-release>{@link io.sphere.sdk.http.HttpResponse} also contains {@link io.sphere.sdk.http.HttpHeaders}.</li>
  <li class=new-in-release>Experimental search filter/facet/sort expression model {@code ProductProjectionSearchModel}. See also {@link io.sphere.sdk.meta.SearchDocumentation}.</li>
  <li class=change-in-release>The {@link io.sphere.sdk.producttypes.ProductType} creation has been simplified (TextAttributeDefinition, LocalizedStringsAttributeDefinition, ... are just AttributeDefinition), see {@link io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand} how to create them.</li>
@@ -1779,8 +1779,8 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <ul>
  <li>{@link AsyncHttpClientAdapter} enables to use a custom underlying Ning HTTP client for settings like proxies or max connections per host.</li>
  <li>The new module {@code java-client-apache-async} contains an {@link ApacheHttpClientAdapter adapter} to use the Apache HTTP client instead of the current default client Ning.</li>
- <li>The {@link io.sphere.sdk.client.QueueSphereClientDecorator} enables to limit the amount of concurrent requests to the platform with a task queue.</li>
- <li>{@code io.sphere.sdk.client.SphereAccessTokenSupplierFactory} is a starting point to create custom access token suppliers for one token (either fetched from commercetools or as String) or auto refreshing for online shops.</li>
+ <li>The {@link io.sphere.sdk.client.QueueSphereClientDecorator} enables to limit the amount of concurrent requests to Composable Commerce with a task queue.</li>
+ <li>{@code io.sphere.sdk.client.SphereAccessTokenSupplierFactory} is a starting point to create custom access token suppliers for one token (either fetched from Composable Commerce or as String) or auto refreshing for online shops.</li>
  </ul>
  </li>
  <li class=new-in-release>Added {@link io.sphere.sdk.client.SphereRequestDecorator} to decorate {@link io.sphere.sdk.client.SphereRequest}s.</li>
@@ -1836,8 +1836,8 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <li class=new-in-release>Added {@link io.sphere.sdk.products.ProductProjection#getVariant(int)} and {@link io.sphere.sdk.products.ProductProjection#getVariantOrMaster(int)} to find a product variant by id.</li>
  <li class=new-in-release>Added {@code VariantIdentifier} to have a container to address product variants which needs a product ID and a variant ID.</li>
  <li class=new-in-release>added {@link io.sphere.sdk.customers.commands.CustomerDeleteCommand} to delete customers.</li>
- <li class=new-in-release>Added {@link io.sphere.sdk.products.commands.updateactions.AddExternalImage} to connect products with images not hosted by the commercetools platform.</li>
- <li class=new-in-release>Added {@link io.sphere.sdk.products.commands.updateactions.RemoveImage} to disconnect images from a product (external images and commercetools platform hosted).</li>
+ <li class=new-in-release>Added {@link io.sphere.sdk.products.commands.updateactions.AddExternalImage} to connect products with images not hosted by the system.</li>
+ <li class=new-in-release>Added {@link io.sphere.sdk.products.commands.updateactions.RemoveImage} to disconnect images from a product (external images and commercetools Composable Commerce hosted).</li>
  <li class=new-in-release>Added {@link io.sphere.sdk.client.SphereAccessTokenSupplier} as authentication method in the {@link io.sphere.sdk.client.SphereClient}.
  It is possible to automatically refresh a token or just pass a token to the client, see {@link io.sphere.sdk.client.SphereClientFactory#createClient(io.sphere.sdk.client.SphereApiConfig, io.sphere.sdk.client.SphereAccessTokenSupplier)} and {@link io.sphere.sdk.client.SphereAccessTokenSupplier#ofConstantToken(String)}.</li>
 
@@ -1884,7 +1884,7 @@ PagedSearchResult<ProductProjection> result = client.execute(search);
  <h3>1.0.0-M7</h3>
 
  <ul>
- <li>Incompatible change: Classes to create templates for new entries in the platform like {@code NewCategory} have been renamed to {@link io.sphere.sdk.categories.CategoryDraft}. </li>
+ <li>Incompatible change: Classes to create templates for new entries in Composable Commerce like {@code NewCategory} have been renamed to {@link io.sphere.sdk.categories.CategoryDraft}. </li>
  <li>Incompatible change: {@link ProductTypeDraft} has now only
  factory methods with an explicit parameter for the attribute declarations to prevent to use
  the getter {@link ProductTypeDraft#getAttributes()} and list add operations. </li>

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/SearchDocumentation.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/SearchDocumentation.java
@@ -13,7 +13,7 @@ import io.sphere.sdk.models.Base;
 
  <p>Currently only products have a search endpoint for {@link io.sphere.sdk.products.ProductProjection} only. Therefore, be aware that the class to create a search request for products is called {@link io.sphere.sdk.products.search.ProductProjectionSearch}.</p>
 
- <p>The following examples in this document are based on the search for products. The product data defined in the platform used for the following code examples are:
+ <p>The following examples in this document are based on the search for products. The product data defined in Composable Commerce used for the following code examples are:
 
  <table border="1" class="doc-table" summary="table that shows the products used for the code examples">
     <tr>
@@ -64,7 +64,7 @@ import io.sphere.sdk.models.Base;
 
 <h3 id=pagination>Pagination</h3>
 
- <p>Use {@link io.sphere.sdk.search.SearchDsl#withOffset(Long)} and {@link io.sphere.sdk.search.SearchDsl#withLimit(Long)} for pagination. An extended explanation about how pagination works in the platform can be found in {@link io.sphere.sdk.meta.QueryDocumentation}.</p>
+ <p>Use {@link io.sphere.sdk.search.SearchDsl#withOffset(Long)} and {@link io.sphere.sdk.search.SearchDsl#withLimit(Long)} for pagination. An extended explanation about how pagination works in the API can be found in {@link io.sphere.sdk.meta.QueryDocumentation}.</p>
 
  <p>The following request skips the first 50 products and limits the result set to only 25 products:</p>
 

--- a/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/TroubleshootingGuide.java
+++ b/commercetools-internal-docs/src/main/java/io/sphere/sdk/meta/TroubleshootingGuide.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.meta;
 /**
  <h3 id="mixed-dependencies">Mixed dependencies</h3>
  <h4>Indications</h4>
- {@code java.lang.NoClassDefFoundError: <a commercetools related class>}
+ {@code java.lang.NoClassDefFoundError: <a Composable Commerce related class>}
  <h4>Possible solutions</h4>
  The JVM SDK depends on multiple modules like the Java client and the models, make sure that they have the same version number in your build file.
 
@@ -37,7 +37,7 @@ package io.sphere.sdk.meta;
 
   <h3 id="jackson-dependency">JSON Jackson Initialization Problems</h3>
   <h4>Indications</h4>
- {@code Could not initialize class <a commercetools related class>}
+ {@code Could not initialize class <a Composable Commerce related class>}
 
  <h4>Possible solutions</h4>
  It could be the case that you use a build tool like Maven which has other code in it depending on an older Jackson version.
@@ -130,7 +130,7 @@ package io.sphere.sdk.meta;
  <h3 id="product-not-found-by-text">Product not found</h3>
  <ul>
     <li>Maybe the product is not published. See {@link io.sphere.sdk.products.commands.updateactions.Publish}.</li>
-    <li>The product was not found for the search because the locale was not activated in the commercetools platform project. Enable it in the Merchant Center.</li>
+    <li>The product was not found for the search because the locale was not activated in the Project. Enable it in the Merchant Center.</li>
  </ul>
  */
 public final class TroubleshootingGuide {

--- a/commercetools-internal-docs/src/test/java/io/sphere/sdk/meta/FormattingDocumentationTest.java
+++ b/commercetools-internal-docs/src/test/java/io/sphere/sdk/meta/FormattingDocumentationTest.java
@@ -176,7 +176,7 @@ public class FormattingDocumentationTest {
 
     @Test
     public void formatZonedDateTime() throws Exception {
-        final String timeAsString = "2015-07-09T07:46:40.230Z";//typical date format from the platform
+        final String timeAsString = "2015-07-09T07:46:40.230Z";//typical date format from the API
         final ZonedDateTime dateTime = ZonedDateTime.parse(timeAsString);
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
         assertThat(dateTime.format(formatter)).isEqualTo("09.07.2015 07:46");

--- a/commercetools-internal-processors/src/main/resources/commercetools-jvm-sdk-processor-templates/commands/deleteCommandInterface.hbs
+++ b/commercetools-internal-processors/src/main/resources/commercetools-jvm-sdk-processor-templates/commands/deleteCommandInterface.hbs
@@ -33,7 +33,7 @@ public interface {{resourceName}}DeleteCommand extends MetaModelReferenceExpansi
     /**
         Creates a command object to delete a {@link {{resourceName}}{{!}}} by ID.
         @param versioned the object to delete (so directly a {@link {{resourceName}}{{!}}}) or just the version/ID information of it
-        @param eraseData  If set to {@literal true}, the commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+        @param eraseData  If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
         @return delete command
      */
     static {{resourceName}}DeleteCommand of(final Versioned<{{resourceName}}> versioned,final boolean eraseData) {
@@ -58,7 +58,7 @@ public interface {{resourceName}}DeleteCommand extends MetaModelReferenceExpansi
         Creates a command object to delete a {@link {{resourceName}}{{!}}} by its {{name}}.
         @param {{name}} the {{name}} of the {{resourceName}} to delete, see {@link {{resourceName}}#get{{capitalizedName}}()}
         @param version the current version of the {{resourceName}}, see {@link {{resourceName}}#getVersion()}
-        @param eraseData  If set to {@literal true}, the commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+        @param eraseData  If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
         @return delete command
     */
     static {{resourceName}}DeleteCommand of{{capitalizedName}}(final String {{name}}, final Long version, final boolean eraseData) {

--- a/commercetools-java-client-ahc-2_0/src/main/java/io/sphere/sdk/client/SphereAsyncHttpClientFactory.java
+++ b/commercetools-java-client-ahc-2_0/src/main/java/io/sphere/sdk/client/SphereAsyncHttpClientFactory.java
@@ -7,7 +7,7 @@ import org.asynchttpclient.DefaultAsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 /**
- * Creates an {@link HttpClient} with a commercetools configured underlying {@link org.asynchttpclient.AsyncHttpClient}.
+ * Creates an {@link HttpClient} with Composable Commerce configured underlying {@link org.asynchttpclient.AsyncHttpClient}.
  */
 public final class SphereAsyncHttpClientFactory extends SphereHttpClientFactory {
     @Deprecated

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClient.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/BlockingSphereClient.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A client for commercetools which provides thread blocking and non-blocking methods to execute a request.
+ * A client for Composable Commerce which provides thread blocking and non-blocking methods to execute a request.
  *
  * The implementations should be thread-safe so they can be used by multiple threads in parallel.
  *
@@ -34,9 +34,9 @@ public interface BlockingSphereClient extends SphereClient {
     /**
      * Executes a request and blocks the caller thread until the response is available or a client specific timeout occurs.
      *
-     * @param sphereRequest request to commercetools to perfom
+     * @param sphereRequest request to Composable Commerce to perform
      * @param <T> type of the result for the request
-     * @return result for the request to commercetools
+     * @return result for the request to Composable Commerce
      * @throws SphereTimeoutException if a timeout occurs
      */
     <T> T executeBlocking(final SphereRequest<T> sphereRequest);
@@ -44,11 +44,11 @@ public interface BlockingSphereClient extends SphereClient {
     /**
      * Executes a request and blocks the caller thread until the response is available or a request specific timeout occurs.
      *
-     * @param sphereRequest request to commercetools to perfom
+     * @param sphereRequest request to Composable Commerce to perform
      * @param timeout the maximum time to wait for this single request
      * @param unit the time unit of the timeout argument
      * @param <T> type of the result for the request
-     * @return result for the request to commercetools
+     * @return result for the request to Composable Commerce
      * @throws SphereTimeoutException if a timeout occurs
      */
     <T> T executeBlocking(final SphereRequest<T> sphereRequest, final long timeout, final TimeUnit unit);
@@ -56,10 +56,10 @@ public interface BlockingSphereClient extends SphereClient {
     /**
      * Executes a request and blocks the caller thread until the response is available or a request specific timeout occurs.
      *
-     * @param sphereRequest request to commercetools to perfom
+     * @param sphereRequest request to Composable Commerce to perform
      * @param duration the maximum duration to wait for this single request
      * @param <T> type of the result for the request
-     * @return result for the request to commercetools
+     * @return result for the request to Composable Commerce
      * @throws SphereTimeoutException if a timeout occurs
      */
     <T> T executeBlocking(final SphereRequest<T> sphereRequest, final Duration duration);

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/DeprecationExceptionSphereClientDecorator.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/DeprecationExceptionSphereClientDecorator.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletionStage;
 /**
  * Decorator for {@link SphereClient}s to throw exceptions on deprecated http calls.
  *
- * <p>If the platform returns a {@value io.sphere.sdk.client.SphereHttpHeaders#X_DEPRECATION_NOTICE} header field,
+ * <p>If the API returns a {@value io.sphere.sdk.client.SphereHttpHeaders#X_DEPRECATION_NOTICE} header field,
  * it does not deserialize the response object in {@link SphereRequest#deserialize(HttpResponse)} but throws a {@link SphereDeprecationException}.</p>
  */
 public final class DeprecationExceptionSphereClientDecorator extends SphereClientDecorator implements SphereClient {

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereClient.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereClient.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 /**
- * A client interface to perform requests to the platform.
+ * A client interface to perform requests to Composable Commerce.
  *
  * <h3 id=instantiation>Instantiation</h3>
  *
@@ -16,13 +16,13 @@ import java.util.concurrent.CompletionStage;
  *
  * {@include.example example.TaxCategoryQueryExample#exampleQuery()}
  *
- * Refer to <a href="../meta/SphereResources.html">resources</a> for known platform requests.
+ * Refer to <a href="../meta/SphereResources.html">resources</a> for known Composable Commerce requests.
  *
  */
 public interface SphereClient extends AutoCloseable {
     /**
-     * Executes asynchronously a request to commercetools. By default it does not have a timeout.
-     * @param sphereRequest request to commercetools to perfom
+     * Executes asynchronously a request to Composable Commerce. By default it does not have a timeout.
+     * @param sphereRequest request to Composable Commerce to perform
      * @param <T> type of the result for the request
      * @return future monad which can contain the result or an exception
      */
@@ -38,7 +38,7 @@ public interface SphereClient extends AutoCloseable {
      * Raw client creation.
      * See also {@link SphereClientFactory}.
      *
-     * @param config platform project and location
+     * @param config Project and location
      * @param httpClient client to execute requests
      * @param tokenSupplier delivery of access tokens
      * @return sphere client
@@ -51,7 +51,7 @@ public interface SphereClient extends AutoCloseable {
      * Raw client creation.
      * See also SphereClientFactory.
      *
-     * @param config platform project and location
+     * @param config Project and location
      * @param httpClient client to execute requests
      * @param tokenSupplier delivery of access tokens
      * @return sphere client

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereClientFactory.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 /**
- * A factory to instantiate platform Java clients which use {@link CompletionStage} as future implementation.
+ * A factory to instantiate Composable Commerce Java clients which use {@link CompletionStage} as future implementation.
  *
  * {@include.example example.JavaClientInstantiationExample}
  */
@@ -21,7 +21,7 @@ public interface SphereClientFactory {
 
     /**
      * Creates a standard client with configurable service URLs. Intended for commercetools staff
-     * developing with a custom platform instance.
+     * developing with a custom Composable Commerce instance.
      *
      * @param config configuration for the client
      * @return client

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereDeprecationException.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereDeprecationException.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.SphereException;
 import java.util.List;
 
 /**
- * Exception thrown by {@link DeprecationExceptionSphereClientDecorator} in case a deprecated feature of the commercetools platform is used.
+ * Exception thrown by {@link DeprecationExceptionSphereClientDecorator} in case a deprecated feature of Composable Commerce is used.
  */
 public class SphereDeprecationException extends SphereException {
     static final long serialVersionUID = 0L;

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereHttpHeaders.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/SphereHttpHeaders.java
@@ -3,14 +3,14 @@ package io.sphere.sdk.client;
 import io.sphere.sdk.models.Base;
 
 /**
- * Holds the names of commercetools proprietary HTTP headers.
+ * Holds the names of commercetools Composable Commerce proprietary HTTP headers.
  */
 public final class SphereHttpHeaders extends Base {
     private SphereHttpHeaders() {
     }
 
     /**
-     * Used for http requests which are deprecated on the commercetools platform.
+     * Used for http requests which are deprecated on Composable Commerce.
      */
     public static final String X_DEPRECATION_NOTICE = "X-DEPRECATION-NOTICE";
 }

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TestDoubleSphereClientFactory.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TestDoubleSphereClientFactory.java
@@ -26,12 +26,12 @@ public final class TestDoubleSphereClientFactory extends Base {
     }
 
     /**
-     * Creates a test double for a platform client which enables to fake http responses from the platform.
+     * Creates a test double for a Composable Commerce client which enables to fake http responses from the API.
      * The client does not need an internet connection.
      *
      * {@include.example io.sphere.sdk.client.TestsDemo#withJson()}
      *
-     * @param function a function which returns a matching object for a platform request.
+     * @param function a function which returns a matching object for a Composable Commerce request.
      * @return sphere client test double
      */
     public static SphereClient createHttpTestDouble(final Function<HttpRequestIntent, HttpResponse> function) {
@@ -69,12 +69,12 @@ public final class TestDoubleSphereClientFactory extends Base {
     }
 
     /**
-     * Creates a test double for a platform client which enables to fake the results of the client as Java object.
+     * Creates a test double for a Composable Commerce client which enables to fake the results of the client as Java object.
      * The client does not need an internet connection.
      *
      * {@include.example io.sphere.sdk.client.TestsDemo#modelInstanceFromJson()}
      *
-     * @param function a function which returns a matching http request for a platform request.
+     * @param function a function which returns a matching http request for a Composable Commerce request.
      * @return sphere client test double
      */
     @SuppressWarnings("unchecked")

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensFacade.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensFacade.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.Base;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Provides facilities to fetch commercetools access and refresh tokens.
+ * Provides facilities to fetch Composable Commerce access and refresh tokens.
  */
 public final class TokensFacade extends Base {
     private TokensFacade() {
@@ -20,7 +20,7 @@ public final class TokensFacade extends Base {
      *
      * {@include.example io.sphere.sdk.client.TokensFacadeIntegrationTest#fetchAccessToken()}
      *
-     * @param authConfig the commercetools project which the token should belong to
+     * @param authConfig the Project which the token should belong to
      * @return token
      */
     public static CompletionStage<Tokens> fetchTokens(final SphereAuthConfig authConfig) {

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensSupplierImpl.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensSupplierImpl.java
@@ -17,7 +17,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
 /**
- * Component that can fetch platform access tokens.
+ * Component that can fetch Composable Commerce access tokens.
  * Does not refresh them,
  */
 final class TokensSupplierImpl extends AutoCloseableService implements TokensSupplier {

--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/package-info.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Provides types to connect to the platform via HTTPS.
+ * Provides types to connect to the API via HTTPS.
  */
 package io.sphere.sdk.client;

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/CustomLineItemDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/CustomLineItemDraft.java
@@ -39,7 +39,7 @@ public interface CustomLineItemDraft extends CustomDraft {
 
     /**
      * Possible custom tax rate.
-     * If set, this tax rate will override the tax rate selected by the platform.
+     * If set, this tax rate will override the tax rate selected by the system.
      *
      * @return external tax rate or null
      * @see #getTaxCategory()

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/RoundingMode.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/RoundingMode.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.sphere.sdk.models.SphereEnumeration;
 
 /**
- * A rounding mode specifies how the platform should round monetary values.
+ * A rounding mode specifies how Composable Commerce should round monetary values.
  */
 public enum RoundingMode implements SphereEnumeration {
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/TaxCalculationMode.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/TaxCalculationMode.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.sphere.sdk.models.SphereEnumeration;
 
 /**
- * A calculation mode specifies how the platform performs calculation of taxes.
+ * A calculation mode specifies how Composable Commerce performs calculation of taxes.
  */
 public enum TaxCalculationMode implements SphereEnumeration{
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/TaxMode.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/TaxMode.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.taxcategories.TaxCategory;
 
 public enum TaxMode implements SphereEnumeration {
     /**
-     * The tax rates are selected by the platform from the {@link TaxCategory tax categories} based on the cart shipping address.
+     * The tax rates are selected by the system from the {@link TaxCategory tax categories} based on the cart shipping address.
      */
     PLATFORM,
 
@@ -58,9 +58,9 @@ public enum TaxMode implements SphereEnumeration {
      * <p>It fails if the products does not have a tax category set</p>
      * {@include.example io.sphere.sdk.carts.ExternalTaxRatesIntegrationTest#errorMovingFromExternalToPlatformTaxMode()}
      *
-     * <p>In case you use {@link CustomLineItem}s as well as external and the platform tax mode it is advised to
+     * <p>In case you use {@link CustomLineItem}s as well as external and Composable Commerce tax mode, it is advised to
      * add the tax category at the time of the creation of the custom line item if you don't know which tax mode will be used later.
-     * A cart with an external tax mode having a custom line item without a tax category cannot transformed into a cart with platform tax calculation,
+     * A cart with an external tax mode having a custom line item without a tax category cannot be transformed into a cart with Composable Commerce tax calculation,
      * to recover from this the custom object needs to be removed and added with a tax category.</p>
      *
      */

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetLineItemPrice.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetLineItemPrice.java
@@ -10,7 +10,7 @@ import javax.money.MonetaryAmount;
 /**
  * Sets the price of a line item and changes the priceMode of the line item to ExternalPrice.
  * If the price mode of the line item is ExternalPrice and no externalPrice is given, the external price is unset
- * and the priceMode is set to Platform.
+ * and the priceMode is set to Composable Commerce.
  *
  * {@doc.gen intro}
  *

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetLineItemTaxRate.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetLineItemTaxRate.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.taxcategories.ExternalTaxRateDraft;
 import javax.annotation.Nullable;
 
 /**
- Sets a new tax rate that overrides the tax rate selected by the platform. If `externalTaxRate` is empty, the platform will select a tax rate as in {@link AddLineItem}.
+ Sets a new tax rate that overrides the tax rate selected by Composable Commerce. If `externalTaxRate` is empty, Composable Commerce will select a tax rate as in {@link AddLineItem}.
 
  {@doc.gen intro}
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethodTaxRate.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/carts/commands/updateactions/SetShippingMethodTaxRate.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.taxcategories.ExternalTaxRateDraft;
 import javax.annotation.Nullable;
 
 /**
- Sets a new tax rate that overrides the tax rate selected by the platform.
+ Sets a new tax rate that overrides the tax rate selected by the system.
 
  {@doc.gen intro}
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/customers/Customer.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customers/Customer.java
@@ -44,14 +44,14 @@ import static java.util.stream.Collectors.toList;
  * <h3 id="verify-email">Verify the customers email address</h3>
  *
  * The customer contains the property {@link Customer#isEmailVerified()}, which is by default false.
- * If the shop is not supposed to use the commercetools platform email authentication and proved the customer email somehow else
+ * If the shop is not supposed to use the commercetools Composable Commerce's email authentication and proved the customer email somehow else
  * then a customer can be created with this field set to true: {@link CustomerDraftBuilder#emailVerified(Boolean)}.
  *
- * To verify the customers email address with commercetools platform first an email token needs to be created with {@link io.sphere.sdk.customers.commands.CustomerCreateEmailTokenCommand}.
+ * To verify the customers email address with Composable Commerce, first an email token needs to be created with {@link io.sphere.sdk.customers.commands.CustomerCreateEmailTokenCommand}.
  * You can specify a certain time frame so that the token gets invalidated at some point.
  * The response contains a token {@link CustomerToken#getValue()} which needs to be sent to the customer.
- * Commercetools platform won't send an email to the customer. The shop must implement this feature.
- * When the customer received the token send he/she needs to submit to the shop and then the shop to the platform with {@link io.sphere.sdk.customers.commands.CustomerVerifyEmailCommand}.
+ * commercetools Composable Commerce won't send an email to the customer. The shop must implement this feature.
+ * When the customer received the token send he/she needs to submit to the shop and then the shop to Composable Commerce with {@link io.sphere.sdk.customers.commands.CustomerVerifyEmailCommand}.
  *
  * <p>Example</p>
  *
@@ -79,8 +79,8 @@ import static java.util.stream.Collectors.toList;
  * This covers the case that the customer forgot the password or just want to change it.
  *
  * First a password reset token needs to be created with {@link CustomerCreatePasswordTokenCommand} by using the customers email.
- * This token ({@link CustomerToken#getValue()} from the result of {@link CustomerCreatePasswordTokenCommand}) needs to be sent to the customers email address by the shop. Commercetools platform won't send the email.
- * The customer receives the token and can submit it to the shop including the new password. To change then the password in the commercetools platform use {@link CustomerPasswordResetCommand}.
+ * This token ({@link CustomerToken#getValue()} from the result of {@link CustomerCreatePasswordTokenCommand}) needs to be sent to the customers email address by the shop. commercetools Composable Commerce won't send the email.
+ * The customer receives the token and can submit it to the shop including the new password. To change then the password in Composable Commerce, use {@link CustomerPasswordResetCommand}.
  * The result of the command is the updated customer, so if the customer needs to sign in after the password change the command {@link io.sphere.sdk.customers.commands.CustomerSignInCommand} is required.
  *
  * {@include.example io.sphere.sdk.customers.commands.CustomerPasswordResetCommandIntegrationTest#execution()}

--- a/commercetools-models/src/main/java/io/sphere/sdk/customers/commands/CustomerCreateEmailTokenCommand.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customers/commands/CustomerCreateEmailTokenCommand.java
@@ -39,7 +39,7 @@ public final class CustomerCreateEmailTokenCommand extends CommandImpl<CustomerT
      * Creates a command object to create a token to verify a customer's email.
      * No optimistic version control is used.
      * @param id the id belonging to the customer
-     * @param timeToLiveInMinutes the time in minutes the token is valid, platform limitation apply
+     * @param timeToLiveInMinutes the time in minutes the token is valid, Composable Commerce limitation apply
      * @return command
      */
     public static CustomerCreateEmailTokenCommand ofCustomerId(final String id, final Integer timeToLiveInMinutes) {
@@ -50,7 +50,7 @@ public final class CustomerCreateEmailTokenCommand extends CommandImpl<CustomerT
      * Creates a command object to create a token to verify a customer's email.
      * No optimistic version control is used.
      * @param customer customer
-     * @param timeToLiveInMinutes the time in minutes the token is valid, platform limitation apply
+     * @param timeToLiveInMinutes the time in minutes the token is valid, Composable Commerce limitation apply
      * @return command
      */
     public static CustomerCreateEmailTokenCommand of(final Identifiable<Customer> customer, final Integer timeToLiveInMinutes) {

--- a/commercetools-models/src/main/java/io/sphere/sdk/customers/commands/CustomerInStoreCreateEmailTokenCommand.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customers/commands/CustomerInStoreCreateEmailTokenCommand.java
@@ -34,7 +34,7 @@ public final class CustomerInStoreCreateEmailTokenCommand extends CommandImpl<Cu
      * Creates a command object to create a token to verify a customer's email.
      * No optimistic version control is used.
      * @param id the id belonging to the customer
-     * @param timeToLiveInMinutes the time in minutes the token is valid, platform limitation apply
+     * @param timeToLiveInMinutes the time in minutes the token is valid, Composable Commerce limitation apply
      * @return command
      */
     public static CustomerInStoreCreateEmailTokenCommand ofCustomerId(final String storeKey, final String id, final Integer timeToLiveInMinutes) {
@@ -45,7 +45,7 @@ public final class CustomerInStoreCreateEmailTokenCommand extends CommandImpl<Cu
      * Creates a command object to create a token to verify a customer's email.
      * No optimistic version control is used.
      * @param customer customer
-     * @param timeToLiveInMinutes the time in minutes the token is valid, platform limitation apply
+     * @param timeToLiveInMinutes the time in minutes the token is valid, Composable Commerce limitation apply
      * @return command
      */
     public static CustomerInStoreCreateEmailTokenCommand of(final String storeKey,final Identifiable<Customer> customer, final Integer timeToLiveInMinutes) {

--- a/commercetools-models/src/main/java/io/sphere/sdk/customobjects/CustomObject.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customobjects/CustomObject.java
@@ -8,7 +8,7 @@ import io.sphere.sdk.models.Referenceable;
 import io.sphere.sdk.models.ResourceView;
 
 /**
-  Custom objects are a way to store arbitrary JSON-formatted data on the platform. It allows you to persist data that does not fit our standard data model.
+  Custom objects are a way to store arbitrary JSON-formatted data in Composable Commerce. It allows you to persist data that does not fit our standard data model.
 
   The storage can be seen as key value store but with an additional prefix called container to improve querying custom objects and provide an additional namespace.
 
@@ -17,7 +17,7 @@ import io.sphere.sdk.models.ResourceView;
 <hr>
 
 A {@link io.sphere.sdk.customobjects.CustomObject} contains an ID, a version, timestamps
-like the other resources in the platform and in addition {@link io.sphere.sdk.customobjects.CustomObject#getContainer()},
+like the other resources in Composable Commerce and in addition {@link io.sphere.sdk.customobjects.CustomObject#getContainer()},
 {@link io.sphere.sdk.customobjects.CustomObject#getKey()} and {@link io.sphere.sdk.customobjects.CustomObject#getValue()}.
 
 <p>Container and key are namespaces like in a key-value store. The value is a JSON structure
@@ -88,9 +88,9 @@ Or you can just override the value using {@link io.sphere.sdk.customobjects.Cust
 <h3 id=increment-example>Using Optimistic Concurrency Control</h3>
 
 <p>In this example we want to create unique readable IDs (successive numbers)
-for customers since the platform returns IDs like 8547b810-9dad-11d1-80b4-44c04fd430c8.</p>
+for customers since the system returns IDs like 8547b810-9dad-11d1-80b4-44c04fd430c8.</p>
 
-The data model contains the last number and the last platform customer ID (just to have more than one field).
+The data model contains the last number and the last Composable Commerce customer ID (just to have more than one field).
 
 {@include.example io.sphere.sdk.customobjects.occexample.CustomerNumberCounter}
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/customobjects/CustomObjectDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customobjects/CustomObjectDraft.java
@@ -63,7 +63,7 @@ public final class CustomObjectDraft<T> extends Base {
      * Creates a draft for updating a custom object. Optimistic concurrency control is used.
      * @param customObject the custom object to override (provides key, container and version)
      * @param newValue the value which should be assigned to the custom object
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T>  The type of the value of the custom object.
      * @return the draft
      */
@@ -87,7 +87,7 @@ public final class CustomObjectDraft<T> extends Base {
      * Creates a draft for updating a custom object. Does not use optimistic concurrency control so the last update wins.
      * @param customObject the custom object to override (provides key, container and version)
      * @param newValue the value which should be assigned to the custom object
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> The type of the value of the custom object.
      * @return the draft
      */
@@ -113,7 +113,7 @@ public final class CustomObjectDraft<T> extends Base {
      * @param container the container
      * @param key the key
      * @param value the value which should be assigned to the custom object
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> The type of the value of the custom object.
      * @return the draft
      */
@@ -140,7 +140,7 @@ public final class CustomObjectDraft<T> extends Base {
      * @param key the key
      * @param value the value which should be assigned to the custom object
      * @param version the version for optimistic locking
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> The type of the value of the custom object.
      * @return the draft
      */

--- a/commercetools-models/src/main/java/io/sphere/sdk/customobjects/commands/CustomObjectDeleteCommand.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customobjects/commands/CustomObjectDeleteCommand.java
@@ -7,7 +7,7 @@ import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.json.TypeReferences;
 
 /**
- * <p>Deletes a custom object in the platform.</p>
+ * <p>Deletes a custom object in the system.</p>
  *
  * {@include.example io.sphere.sdk.customobjects.commands.CustomObjectDeleteCommandIntegrationTest#demo()}
  *
@@ -18,7 +18,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
     /**
      * Deletes a custom object without optimistic concurrency control and uses the delete endpoint via container and key and returns the old custom object with the in {@code valueTypeReference}specified value type.
      * @param customObject the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> type of the value of the custom object
      * @return custom object
      */
@@ -41,7 +41,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * Deletes a custom object without optimistic concurrency control and uses the delete endpoint via container and key and returns the old custom object with the in {@code valueTypeReference}specified value type.
      * @param container the container name of the custom object to delete
      * @param key the key name of the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> type of the value of the custom object
      * @return custom object with a JsonNode value
      */
@@ -98,7 +98,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * Convenience method to not specify the {@link com.fasterxml.jackson.core.type.TypeReference} but lacking the accessible value in the result.
      * @param id the id of the custom object to delete
      * @param version the version of the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T> type of the value of the custom object
      * @return custom object with a JsonNode value
      */
@@ -126,8 +126,8 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * Deletes a custom object without optimistic concurrency control and uses the delete endpoint via container and key and returns the old custom object with the in {@code valueTypeReference}specified value type.
      *
      * @param customObject       the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
-     * @param eraseData          If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
+     * @param eraseData          If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @param <T>                type of the value of the custom object
      * @return custom object
      */
@@ -141,7 +141,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * @param customObject the custom object to delete
      * @param valueClass   the class of the value, if it not uses generics like lists, typically for POJOs
      * @param <T>          type of the value of the custom object
-     * @param eraseData    If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData    If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object
      */
     static <T> DeleteCommand<CustomObject<T>> of(final CustomObject<T> customObject, final Class<T> valueClass, final boolean eraseData) {
@@ -153,9 +153,9 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      *
      * @param container          the container name of the custom object to delete
      * @param key                the key name of the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T>                type of the value of the custom object
-     * @param eraseData          If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData          If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static <T> DeleteCommand<CustomObject<T>> of(final String container, final String key, final TypeReference<T> valueTypeReference, final boolean eraseData) {
@@ -169,7 +169,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * @param key        the key name of the custom object to delete
      * @param valueClass the class of the value, if it not uses generics like lists, typically for POJOs
      * @param <T>        type of the value of the custom object
-     * @param eraseData  If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData  If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static <T> DeleteCommand<CustomObject<T>> of(final String container, final String key, final Class<T> valueClass, final boolean eraseData) {
@@ -181,7 +181,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * Convenience method to not specify the {@link com.fasterxml.jackson.core.type.TypeReference} but lacking the accessible value in the result.
      *
      * @param customObject the custom object to delete
-     * @param eraseData    If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData    If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static DeleteCommand<CustomObject<JsonNode>> ofJsonNode(final CustomObject<?> customObject, final boolean eraseData) {
@@ -194,7 +194,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      *
      * @param container the container name of the custom object to delete
      * @param key       the key name of the custom object to delete
-     * @param eraseData If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static DeleteCommand<CustomObject<JsonNode>> ofJsonNode(final String container, final String key, final boolean eraseData) {
@@ -207,7 +207,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      *
      * @param id        the id of the custom object to delete
      * @param version   the version of the custom object to delete
-     * @param eraseData If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static DeleteCommand<CustomObject<JsonNode>> ofJsonNode(final String id, final Long version, final boolean eraseData) {
@@ -220,9 +220,9 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      *
      * @param id                 the id of the custom object to delete
      * @param version            the version of the custom object to delete
-     * @param valueTypeReference the type reference to deserialize the updated custom object from the platform response
+     * @param valueTypeReference the type reference to deserialize the updated custom object from the API response
      * @param <T>                type of the value of the custom object
-     * @param eraseData          If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData          If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static <T> DeleteCommand<CustomObject<T>> of(final String id, final Long version, final TypeReference<T> valueTypeReference, final boolean eraseData) {
@@ -238,7 +238,7 @@ public interface CustomObjectDeleteCommand<T> extends DeleteCommand<CustomObject
      * @param version    the version of the custom object to delete
      * @param valueClass the class of the value, if it not uses generics like lists, typically for POJOs
      * @param <T>        type of the value of the custom object
-     * @param eraseData  If set to {@literal true},  commercetools platform guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
+     * @param eraseData  If set to {@literal true}, Composable Commerce guarantees that all personal data related to the particular object, including invisible data, is erased, in compliance with the GDPR.
      * @return custom object with a JsonNode value
      */
     static <T> DeleteCommand<CustomObject<T>> of(final String id, final Long version, final Class<T> valueClass, final boolean eraseData) {

--- a/commercetools-models/src/main/java/io/sphere/sdk/customobjects/commands/CustomObjectDeleteCommandImpl.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customobjects/commands/CustomObjectDeleteCommandImpl.java
@@ -12,7 +12,7 @@ import io.sphere.sdk.json.SphereJsonUtils;
 import static java.lang.String.format;
 
 /**
- * Deletes a custom object in the platform.
+ * Deletes a custom object in the system.
  *
  *
  */

--- a/commercetools-models/src/main/java/io/sphere/sdk/orders/ProductVariantImportDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/orders/ProductVariantImportDraft.java
@@ -31,7 +31,7 @@ public interface ProductVariantImportDraft {
     String getSku();
 
     /**
-     * Field is not part of the platform API, it is used to initialize {@link LineItemImportDraftBuilder} correctly.
+     * Field is not part of the API, it is used to initialize {@link LineItemImportDraftBuilder} correctly.
      * @return the product ID
      */
     @Nullable

--- a/commercetools-models/src/main/java/io/sphere/sdk/producttypes/MetaProductType.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/producttypes/MetaProductType.java
@@ -7,7 +7,7 @@ import java.util.*;
 /**
  * All product types merged into one.
  *
- * In the platform different product types can be created but the attribute type for one attribute name and labels must be consistent.
+ * In Composable Commerce, different product types can be created but the attribute type for one attribute name and labels must be consistent.
  * So this container can contain all attribute information for all product types.
  *
  */

--- a/commercetools-models/src/main/java/io/sphere/sdk/producttypes/ProductType.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/producttypes/ProductType.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 @ResourceInfo(pluralName = "product types", pathElement = "product-types")
 @HasByIdGetEndpoint(javadocSummary = "Retrieves a product type by a known ID.", includeExamples = "io.sphere.sdk.producttypes.queries.ProductTypeByIdGetIntegrationTest#execution()")
 @HasByKeyGetEndpoint(javadocSummary = "Retrieves a product type by a known key.", includeExamples = "io.sphere.sdk.producttypes.queries.ProductTypeByKeyGetIntegrationTest#execution()")
-@HasCreateCommand(javadocSummary = "Command to create a {@link io.sphere.sdk.producttypes.ProductType} in the platform.\n" +
+@HasCreateCommand(javadocSummary = "Command to create a {@link io.sphere.sdk.producttypes.ProductType} in Composable Commerce.\n" +
         "\n" +
         "\n" +
         "  <p>{@link io.sphere.sdk.producttypes.ProductType}s can be created in the backend by executing a {@link io.sphere.sdk.producttypes.commands.ProductTypeCreateCommand}:</p>\n" +

--- a/commercetools-models/src/main/java/io/sphere/sdk/producttypes/ProductTypeDraft.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/producttypes/ProductTypeDraft.java
@@ -28,7 +28,7 @@ public interface ProductTypeDraft extends WithKey {
      * Creates a input object to create a {@link ProductType}.
      *
      * @param key         unique key to identify the created {@link ProductType}
-     * @param name        the name of the product type, the platform does not check that the name will be unique so it is best practice to check if a product type of this name already exists
+     * @param name        the name of the product type, Composable Commerce does not check that the name will be unique so it is best practice to check if a product type of this name already exists
      * @param description description of the product type
      * @param attributes  definitions of attributes for the product type
      * @return draft for a product type

--- a/commercetools-models/src/main/java/io/sphere/sdk/reviews/Review.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/reviews/Review.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 
  <p>If we have an approval process for a review to be used for a product or a channel, we model the approval process with a state machine.</p>
 
- <p>First of all, once per commercetools project, we create the approved state. Then we create the initial to-approve state, which has a possible transition to the approved state:</p>
+ <p>First of all, once per Project, we create the approved state. Then we create the initial to-approve state, which has a possible transition to the approved state:</p>
 
  {@include.example io.sphere.sdk.reviews.approvaldemo.CreateReviewStates}
 

--- a/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/Destination.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/Destination.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * A destination contains all info necessary for the commercetools platform to deliver a message onto your Message Queue.
+ * A destination contains all info necessary for the Composable Commerce to deliver a message onto your Message Queue.
  * Message Queues can be differentiated by the sub types of this interface.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = true)

--- a/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/package-info.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/subscriptions/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Subscriptions are used to trigger an asynchronous background process in response to an event on the commercetools platform.
+ * Subscriptions are used to trigger an asynchronous background process in response to an event on commercetools Composable Commerce.
  *
  * Common use cases include sending an Order Confirmation Email, charging a Credit Card after the delivery has been made,
  * or synchronizing customer accounts to a CRM system.

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/ExternalTaxRatesIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/ExternalTaxRatesIntegrationTest.java
@@ -304,7 +304,7 @@ public class ExternalTaxRatesIntegrationTest extends IntegrationTest {
     @Test
     public void addLineItemOnPlatformCart() {
         withProductOfPrices(client(), singletonList(PriceDraft.of(EURO_10)), (Product product) -> {
-            final CartDraft draft = CartDraft.of(EUR);//uses by default platform!
+            final CartDraft draft = CartDraft.of(EUR);//uses by default Composable Commerce!
             withCartDraft(client(), draft, (Cart cart) -> {
                 final int quantity = 3;
                 final int variantId = product.getMasterData().getStaged().getMasterVariant().getId();

--- a/commercetools-models/src/test/java/io/sphere/sdk/states/StateFixtures.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/states/StateFixtures.java
@@ -77,7 +77,7 @@ public class StateFixtures {
      * @param consumer consumer which uses the two states
      */
     public static void withStandardStates(final BlockingSphereClient client, final BiConsumer<State, State> consumer) {
-        final String keyA = "Initial";//given from the platform
+        final String keyA = "Initial";//given from the API
         final String keyB = StateFixtures.class + "_B";
         final State stateB = client.executeBlocking(StateQuery.of().byKey(keyB)).head().orElseGet(() -> createStateByKey(client, keyB));
         final State stateA = client.executeBlocking(StateQuery.of().byKey(keyA)).head()

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/BadRequestException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/BadRequestException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * HTTP code 400 response from the platform.
+ * HTTP code 400 response from the API.
  *
  * <p>Typically the subclass {@link ErrorResponseException} is thrown.</p>
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ClientErrorException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ClientErrorException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * Exceptions for commercetools platform http responses with an error code 4xx.
+ * Exceptions for Composable Commerce HTTP responses with an error code 4xx.
  */
 public class ClientErrorException extends SphereServiceException {
     private static final long serialVersionUID = 0L;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ErrorResponseException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ErrorResponseException.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  Typical exception for bad requests containing error information.
 
- <p>A <a href="https://docs.commercetools.com/http-api-errors.html#400-bad-request" target="_blank">list of error codes</a> can be found on the commercetools website.</p>
+ <p>A <a href="https://docs.commercetools.com/http-api-errors.html#400-bad-request" target="_blank">list of error codes</a> can be found on the commercetools Composable Commerce website.</p>
 
  */
 public class ErrorResponseException extends BadRequestException implements ErrorResponse {

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ForbiddenException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ForbiddenException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * The commercetools platform received the request but refuses to process it, typically to insufficient rights.
+ * The commercetools Composable Commerce API received the request but refuses to process it, typically to insufficient rights.
  *
  * For example it happens if an access token has been received to view products but a request to the customers endpoint is requested.
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/HttpRequestIntent.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/HttpRequestIntent.java
@@ -9,7 +9,7 @@ import java.io.File;
 import static io.sphere.sdk.http.HttpHeaders.CONTENT_TYPE;
 
 /**
- * Expresses the http request domain model form commercetools platform as a draft for {@link HttpRequest}.
+ * Expresses the HTTP request domain model from commercetools Composable Commerce as a draft for {@link HttpRequest}.
  */
 public final class HttpRequestIntent extends Base {
     private final HttpMethod httpMethod;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidTokenException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/InvalidTokenException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * Exception raised in case the access token is not valid for the used commercetools platform project.
+ * Exception raised in case the access token is not valid for the used Project.
  */
 public class InvalidTokenException extends UnauthorizedException {
     private static final long serialVersionUID = 0L;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/RequestEntityTooLargeException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/RequestEntityTooLargeException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * HTTP code 413 response from the platform.
+ * HTTP code 413 response from the API.
  *
  * Probable error cause: Predicate for a query is too long. Try to split the request into multiple ones or use the in operator.
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ServerErrorException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ServerErrorException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * The platform answered with a HTTP response code of &gt;= 500.
+ * The API answered with a HTTP response code of &gt;= 500.
  *
  * Simulate this server conditions in test:
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ServiceUnavailableException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/ServiceUnavailableException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * The platform is currently not available.
+ * The Composable Commerce API is currently not available.
  *
  * <p>To simulate for tests this exception see {@link SphereServiceException}.</p>
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereApiConfig.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereApiConfig.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.client;
 import static io.sphere.sdk.client.ClientPackage.API_URL;
 
 /**
- * Configuration to make request for a platform web service, does not include authentication configuration or tokens.
+ * Configuration to make request for a Composable Commerce web service, does not include authentication configuration or tokens.
  */
 public interface SphereApiConfig extends SphereCorrelationIdConfig {
     String getApiUrl();

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereAuthConfig.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereAuthConfig.java
@@ -7,7 +7,7 @@ import static io.sphere.sdk.client.ClientPackage.AUTH_URL;
 import static io.sphere.sdk.client.ClientPackage.DEFAULT_SCOPES;
 
 /**
- * Contains the configuration to fetch access keys for the commercetools platform.
+ * Contains the configuration to fetch access keys for the Composable Commerce API.
  *
  * @see SphereAuthConfigBuilder
  */
@@ -48,7 +48,7 @@ public interface SphereAuthConfig {
     default List<String> getRawScopes() {
         return DEFAULT_SCOPES.stream().map(s -> s + ":" + getProjectKey()).collect(Collectors.toList());
     }
-    
+
     static SphereAuthConfig of(final String projectKey, final String clientId, final String clientSecret) {
         return of(projectKey, clientId, clientSecret, AUTH_URL);
     }

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import static io.sphere.sdk.client.ClientPackage.*;
 
 /**
- * The full api and auth configuration for a commercetools client.
+ * The full api and auth configuration for a Composable Commerce client.
  *
  * @see SphereClientConfigBuilder
  *
@@ -148,7 +148,7 @@ public final class SphereClientConfig extends Base implements SphereAuthConfig, 
     /**
      Creates a {@link SphereClientConfig} using {@link Properties} using {@code prefix} as namespace parameter.
 
-     An example properties file with "commercetools." (including the dot) as {@code prefix}:
+     An example properties file with "commercetoComposable Commerceols." (including the dot) as {@code prefix}:
      <pre>{@code
     commercetools.projectKey=YOUR project key without quotes
     commercetools.clientId=YOUR client id without quotes
@@ -169,7 +169,7 @@ public final class SphereClientConfig extends Base implements SphereAuthConfig, 
      {@value #PROPERTIES_KEY_API_URL_SUFFIX} and
      {@value #PROPERTIES_KEY_SCOPES_SUFFIX}.
 
-     @param properties properties containing the commercetools platform credentials
+     @param properties properties containing the Composable Commerce HTTP API credentials
      @param prefix prefix of the property keys
      @return a new {@link SphereClientConfig} containing the values of the properties.
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientUtils.java
@@ -15,7 +15,7 @@ public final class SphereClientUtils {
     }
 
     /**
-     * Waits with a timeout for RESPONSES of a commercetools client wrapped in a {@link CompletionStage}.
+     * Waits with a timeout for RESPONSES of a Composable Commerce client wrapped in a {@link CompletionStage}.
      * This method should not be used for other {@link CompletionStage}s since it is throwing {@link io.sphere.sdk.models.SphereException}s.
      *
      * @param completionStage the future monad to wait for
@@ -30,7 +30,7 @@ public final class SphereClientUtils {
     }
 
     /**
-     * Waits with a timeout for RESPONSES of a commercetools client wrapped in a {@link CompletionStage}.
+     * Waits with a timeout for RESPONSES of a Composable Commerce client wrapped in a {@link CompletionStage}.
      * This method should not be used for other {@link CompletionStage}s since it is throwing {@link io.sphere.sdk.models.SphereException}s.
      *
      * @param completionStage the future monad to wait for
@@ -44,7 +44,7 @@ public final class SphereClientUtils {
     }
 
     /**
-     * Waits with a timeout for RESPONSES of a commercetools client wrapped in a {@link CompletionStage}.
+     * Waits with a timeout for RESPONSES of a Composable Commerce client wrapped in a {@link CompletionStage}.
      * This method should not be used for other {@link CompletionStage}s since it is throwing {@link io.sphere.sdk.models.SphereException}s.
      *
      * @param completionStage the future monad to wait for
@@ -59,7 +59,7 @@ public final class SphereClientUtils {
     }
 
     /**
-     * Waits with a timeout for RESPONSES of a commercetools client wrapped in a {@link CompletionStage}.
+     * Waits with a timeout for RESPONSES of a Composable Commerce client wrapped in a {@link CompletionStage}.
      * This method should not be used for other {@link CompletionStage}s since it is throwing {@link io.sphere.sdk.models.SphereException}s.
      *
      * @param completionStage the future monad to wait for

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereRequest.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereRequest.java
@@ -20,7 +20,7 @@ public interface SphereRequest<T> {
      Before calling this method, check with {@link #canDeserialize(HttpResponse)} if the response can be consumed.
 
      @return the deserialized object
-     @param httpResponse the http response of the platform
+     @param httpResponse the http response of the API
      */
     @Nullable
     T deserialize(final HttpResponse httpResponse);

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereServiceException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereServiceException.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 /**
  *
- * <span id="exception-summary">Exception thrown when the platform responds<br>with a status code other than HTTP 2xx.</span>
+ * <span id="exception-summary">Exception thrown when the API responds<br>with a status code other than HTTP 2xx.</span>
  *
  * <p>For inspiration how to create exceptions in unit tests:</p>
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SuspendedProjectException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SuspendedProjectException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * when trying to make a call to commercetools with suspended project
+ * when trying to make a call to Composable Commerce with suspended Project
  *
  */
 public class SuspendedProjectException extends UnauthorizedException{

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/UnauthorizedException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/UnauthorizedException.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.client;
 
 /**
- * Unauthorized access to the commercetools platform with either invalid client credentials or tokens.
+ * Unauthorized access to the Composable Commerce API with either invalid client credentials or tokens.
  * Most likely the subclass exceptions {@link InvalidClientCredentialsException} and {@link InvalidTokenException} will be thrown.
  *
  */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/Command.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/Command.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.commands;
 import io.sphere.sdk.client.SphereRequest;
 
 /**
- * A command represents a request to update the state of platform entities.
+ * A command represents a request to update the state of the Composable Commerce entities.
  *
  * @param <T> the type of the result of the command
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/CreateCommand.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/CreateCommand.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.commands;
 
 /**
- * Command to create a resource in the platform.
+ * Command to create a resource in the system.
  *
  * @param <T> the type of the result of the command
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/CreateCommandImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/CreateCommandImpl.java
@@ -8,7 +8,7 @@ import static io.sphere.sdk.json.SphereJsonUtils.toJsonString;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Base class to implement commands which create a resource in the platform.
+ * Base class to implement commands which create a resource in the system.
  *
  * @param <T> the type of the result of the command
  * @param <D> class which will serialized as JSON command body, most likely a template

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DeleteCommand.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DeleteCommand.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.commands;
 
 /**
- * Command which deletes one or more resources in the platform.
+ * Command which deletes one or more resources in the system.
  *
  * @param <T> the type of the result of the command
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DraftBasedCreateCommand.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DraftBasedCreateCommand.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.commands;
 
 /**
- * Command to create a resource in commercetools based on a draft object.
+ * Command to create a resource in Composable Commerce based on a draft object.
  *
  * @param <T> the type of the result of the command
  * @param <D> the type of the draft (body of the command)

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DraftBasedCreateCommandDsl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/DraftBasedCreateCommandDsl.java
@@ -1,7 +1,7 @@
 package io.sphere.sdk.commands;
 
 /**
- * Command to create a resource in commercetools based on a draft object and having a wither to replace the current draft.
+ * Command to create a resource in Composable Commerce based on a draft object and having a wither to replace the current draft.
  *
  * @param <T> the type of the result of the command
  * @param <D> the type of the draft (body of the command)

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelByIdDeleteCommandImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelByIdDeleteCommandImpl.java
@@ -21,7 +21,7 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Internal base class to implement commands which deletes a resource by ID in the platform.
+ * Internal base class to implement commands which deletes a resource by ID in the system.
  *
  * @param <T> the type of the result of the command
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelCreateCommandImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelCreateCommandImpl.java
@@ -19,7 +19,7 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Internal base class to implement commands which create a resource in the platform.
+ * Internal base class to implement commands which create a resource in the system.
  *
  * @param <T> the type of the result of the command
  * @param <C> class which will serialized as JSON command body, most likely a template

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelUpdateCommandDslImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/MetaModelUpdateCommandDslImpl.java
@@ -24,7 +24,7 @@ import static io.sphere.sdk.utils.SphereInternalUtils.listOf;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Internal base class to implement commands that change one resource in the platform.
+ * Internal base class to implement commands that change one resource in the system.
  *
  * @param <T> the type of the result of the command
  * @param <C> class which will serialized as JSON command body, most likely a template

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/StagedUpdateActionBase.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/StagedUpdateActionBase.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.models.Base;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Operation which can be performed to change the state of a resource in the platform.
+ * Operation which can be performed to change the state of a resource in the system.
  *
  * @param <T> the context of the update action
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/UpdateActionImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/UpdateActionImpl.java
@@ -5,7 +5,7 @@ import io.sphere.sdk.models.Base;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Operation which can be performed to change the state of a resource in the platform.
+ * Operation which can be performed to change the state of a resource in the system.
  *
  * @param <T> the context of the update action
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/UpdateCommand.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/UpdateCommand.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.commands;
 import java.util.List;
 
 /**
- * Command which updates a commercetools resource based on a list of update actions.
+ * Command which updates a Composable Commerce resource based on a list of update actions.
  * @param <T> type of the updated object
  */
 public interface UpdateCommand<T> extends Command<T> {

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/package-info.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/commands/package-info.java
@@ -1,4 +1,4 @@
 /**
- * This package provide tools to change objects in the platform.
+ * This package provide tools to change objects in the system.
  */
 package io.sphere.sdk.commands;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/expansion/ExpansionPath.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/expansion/ExpansionPath.java
@@ -8,7 +8,7 @@ package io.sphere.sdk.expansion;
 public interface ExpansionPath<I> {
 
     /**
-     * Returns a platform reference expansion path expression.
+     * Returns a Composable Commerce reference expansion path expression.
      * @return String with unescaped expand path expression.
      */
     String toSphereExpand();

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/expansion/ReferenceExpansionSupport.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/expansion/ReferenceExpansionSupport.java
@@ -3,8 +3,8 @@ package io.sphere.sdk.expansion;
 import java.util.List;
 
 /**
- * Marker interface for commercetools endpoints which support reference expansion
- * @param <T> aggegate root which has references which can expanded. Example: ProductProjection
+ * Marker interface for Composable Commerce endpoints which support reference expansion
+ * @param <T> aggregate root which has references which can expanded. Example: ProductProjection
  */
 public interface ReferenceExpansionSupport<T> extends ExpansionPathContainer<T> {
     @Override

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/JsonException.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/JsonException.java
@@ -6,7 +6,7 @@ import io.sphere.sdk.http.HttpResponse;
 /**
  * Exception concerning JSON.
  *
- * This may occur by parsing JSON from the platform and the POJO mapping does not work correctly.
+ * This may occur by parsing JSON from the Composable Commerce API and the POJO mapping does not work correctly.
  *
  * <h3>No suitable constructor</h3>
  * {@code detailMessage: com.fasterxml.jackson.databind.JsonMappingException:

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/SphereJsonUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/SphereJsonUtils.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Public utility class to work with JSON from the commercetools platform.
+ * Public utility class to work with JSON from commercetools Composable Commerce.
  * <p>
  * <p>If an error occurs, the {@link JsonException} (a {@link RuntimeException}) will be thrown:</p>
  * <p>
@@ -57,10 +57,10 @@ public final class SphereJsonUtils {
      * <li>Jackson config: do not use getters as setters</li>
      * <li>Jackson config: do not serialize null value properties</li>
      * <li>Serialize LinkedHashSet as Set</li>
-     * <li>commercetools LocalizedString</li>
-     * <li>commercetools Time, Date, DateTime</li>
-     * <li>commercetools Money for Java MonetaryAmount</li>
-     * <li>commercetools Enum</li>
+     * <li>Composable Commerce LocalizedString</li>
+     * <li>Composable Commerce Time, Date, DateTime</li>
+     * <li>Composable Commerce Money for Java MonetaryAmount</li>
+     * <li>Composable Commerce Enum</li>
      * </ul>
      *
      * @param objectMapper the object mapper to configure
@@ -85,7 +85,7 @@ public final class SphereJsonUtils {
     }
 
     /**
-     * Converts a commercetools platform Java object to JSON as String (one liner).
+     * Converts a commercetools Composable Commerce Java object to JSON as String (one liner).
      * <p>
      * {@include.example io.sphere.sdk.json.SphereJsonUtilsTest#toJsonString()}
      *
@@ -97,7 +97,7 @@ public final class SphereJsonUtils {
     }
 
     /**
-     * Converts a commercetools platform Java object to JSON as String (pretty).
+     * Converts a Composable Commerce Java object to JSON as String (pretty).
      * <p>
      * {@include.example io.sphere.sdk.json.SphereJsonUtilsTest#toPrettyJsonString()}
      *
@@ -109,7 +109,7 @@ public final class SphereJsonUtils {
     }
 
     /**
-     * Converts a commercetools platform Java object to JSON as {@link JsonNode}.
+     * Converts a Composable Commerce Java object to JSON as {@link JsonNode}.
      * <p>If {@code value} is of type String and contains JSON data, that will be ignored, {@code value} will be treated as just any String.
      * If you want to parse a JSON String to a JsonNode use {@link SphereJsonUtils#parse(java.lang.String)} instead.</p>
      * <p>
@@ -263,7 +263,7 @@ public final class SphereJsonUtils {
     }
 
     /**
-     * Creates a new {@link ObjectNode} created by the commercetools platform object mapper.
+     * Creates a new {@link ObjectNode} created by the commercetools Composable Commerce object mapper.
      * <p>
      * {@include.example io.sphere.sdk.json.SphereJsonUtilsTest#readObjectFromJsonNodeWithClass()}
      *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/package-info.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/json/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Provides utils the JSON mapping from and to the platform.
+ * Provides utils the JSON mapping from and to the system.
  */
 package io.sphere.sdk.json;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/Reference.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/Reference.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 /**
- * A {@link io.sphere.sdk.models.Reference} is a loose reference to another resource on the platform.
+ * A {@link io.sphere.sdk.models.Reference} is a loose reference to another resource in Composable Commerce.
  *
  * <p>The reference <em>may</em> have a copy of the referenced object available via the method {@link io.sphere.sdk.models.Reference#getObj()} on {@link io.sphere.sdk.models.Reference#getObj() certain conditions}.</p>
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/Resource.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/Resource.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.models;
 import java.time.ZonedDateTime;
 
 /**
- * A default model is a real resource in the platform which can be referenced and always consists of the fields
+ * A default model is a real resource in Composable Commerce which can be referenced and always consists of the fields
  * id, version, createdAt, lastModifiedAt.
  * @param <T> the interface which inherits from this interface, example: {@code interface Category extends Resource<Category>}
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/SphereEnumeration.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/SphereEnumeration.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Set of enum constants in the commercetools platform.
+ * Set of enum constants in Composable Commerce.
  *
  * <p>Hints for importing {@link SphereEnumeration}s:</p>
  *

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/errors/InvalidJsonInputError.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/errors/InvalidJsonInputError.java
@@ -3,7 +3,7 @@ package io.sphere.sdk.models.errors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
- * Invalid JSON was sent to the platform.
+ * Invalid JSON was sent to Composable Commerce.
  */
 public final class InvalidJsonInputError extends SphereError {
     private final String detailedErrorMessage;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/errors/package-info.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/errors/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Provides base classes for errors related to the commercetools platform.
+ * Provides base classes for errors related to Composable Commerce.
  */
 package io.sphere.sdk.models.errors;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/package-info.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/models/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Provides the common API types of the platform.
+ * Provides the common API types of Composable Commerce.
  */
 package io.sphere.sdk.models;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/SearchDsl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/SearchDsl.java
@@ -8,14 +8,14 @@ public interface SearchDsl<T, C extends SearchDsl<T, C>> extends ResourceSearch<
 
     /**
      * Returns a new object with the new text as search text.
-     * @param text the new search text with locale, the locale should be enabled for the commercetools platform project (see the project settings in the Merchant Center)
+     * @param text the new search text with locale, the locale should be enabled for the Project (see the project settings in the Merchant Center)
      * @return a new object with {@code text}
      */
     C withText(final LocalizedStringEntry text);
 
     /**
      * Returns a new object with the new text as search text.
-     * @param locale the new locale, the locale should be enabled for the commercetools platform project (see the project settings in the Merchant Center)
+     * @param locale the new locale, the locale should be enabled for the Project (see the project settings in the Merchant Center)
      * @param text the new search text
      * @return a new object with {@code text}
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MultiValueSortSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/MultiValueSortSearchModel.java
@@ -50,7 +50,7 @@ public final class MultiValueSortSearchModel<T> extends SortSearchModelImpl<T> {
 
     /**
      * Creates an instance of the search model to generate multi-valued sort expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
      * @param <T> type of the resource
      * @return new instance of MultiValueSortSearchModel
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFacetSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFacetSearchModel.java
@@ -109,8 +109,8 @@ public final class RangeTermFacetSearchModel<T, V extends Comparable<? super V>>
 
     /**
      * Creates an instance of the search model to generate range and term facet expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of RangeTermFacetSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFacetedSearchSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFacetedSearchSearchModel.java
@@ -87,7 +87,7 @@ public final class RangeTermFacetedSearchSearchModel<T> extends RangeTermFaceted
 
     /**
      * Creates an instance of the search model to generate range and term faceted search expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
      * @param <T> type of the resource
      * @return new instance of RangeTermFacetAndFilterSearchModel
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/RangeTermFilterSearchModel.java
@@ -98,8 +98,8 @@ public final class RangeTermFilterSearchModel<T, V extends Comparable<? super V>
 
     /**
      * Creates an instance of the search model to generate range and term filter expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of RangeTermFilterSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SingleValueSortSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/SingleValueSortSearchModel.java
@@ -24,7 +24,7 @@ public final class SingleValueSortSearchModel<T> extends SortSearchModelImpl<T> 
 
     /**
      * Creates an instance of the search model to generate single-valued sort expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
      * @param <T> type of the resource
      * @return new instance of SingleValueSortSearchModel
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetSearchModel.java
@@ -30,8 +30,8 @@ public interface TermFacetSearchModel<T, V> extends FacetSearchModel<T, V> {
 
     /**
      * Creates an instance of the search model to generate term facet expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of TermFacetSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetSearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetSearchModelImpl.java
@@ -62,8 +62,8 @@ public class TermFacetSearchModelImpl<T, V> extends TermFacetBaseSearchModel<T, 
 
     /**
      * Creates an instance of the search model to generate term facet expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of TermFacetSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetedSearchSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFacetedSearchSearchModel.java
@@ -34,7 +34,7 @@ public final class TermFacetedSearchSearchModel<T> extends TermFacetedSearchBase
 
     /**
      * Creates an instance of the search model to generate term faceted search expressions.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
      * @param <T> type of the resource
      * @return new instance of TermFacetAndFilterSearchModel
      */

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterExistsAndMissingSearchModel.java
@@ -32,8 +32,8 @@ public interface TermFilterExistsAndMissingSearchModel<T, V> extends TermFilterS
 
     /**
      * Creates an instance of the search model to generate term filters.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of TermFilterSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModel.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModel.java
@@ -31,8 +31,8 @@ public interface TermFilterSearchModel<T, V> extends FilterSearchModel<T, V> {
 
     /**
      * Creates an instance of the search model to generate term filters.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of TermFilterSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModelImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TermFilterSearchModelImpl.java
@@ -50,8 +50,8 @@ public class TermFilterSearchModelImpl<T, V> extends TermFilterBaseSearchModel<T
 
     /**
      * Creates an instance of the search model to generate term filters.
-     * @param attributePath the path of the attribute as expected by Commercetools Platform (e.g. "variants.attributes.color.key")
-     * @param typeSerializer the function to convert the provided value to a string accepted by Commercetools Platform
+     * @param attributePath the path of the attribute as expected by Composable Commerce (e.g. "variants.attributes.color.key")
+     * @param typeSerializer the function to convert the provided value to a string accepted by Composable Commerce
      * @param <T> type of the resource
      * @param <V> type of the value
      * @return new instance of TermFilterSearchModel

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TypeSerializer.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/search/model/TypeSerializer.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import static java.time.format.DateTimeFormatter.*;
 
 /**
- * Serializer to transform certain types to Commercetools Platform format on search endpoint.
+ * Serializer to transform certain types to Composable Commerce's format on search endpoint.
  * @param <V> type of the data to transform.
  */
 public final class TypeSerializer<V> extends Base implements Function<V, String> {

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/utils/HighPrecisionMoneyImpl.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/utils/HighPrecisionMoneyImpl.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 /**
  * A variant of {@link MoneyImpl}, this class can be used when the user intends to pass to high precision
  * price, the fractions taken into account can be specified in fractions digits, and it allows to fractionDigits up or down
- * the platform precision for a particular price.
+ * the system precision for a particular price.
  */
 public final class HighPrecisionMoneyImpl extends Base implements MonetaryAmount {
     private final MonetaryAmount money;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/utils/SphereInternalLogger.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/utils/SphereInternalLogger.java
@@ -25,16 +25,16 @@ import java.util.function.Supplier;
  *  <p>The child loggers of sphere are the endpoints, so for example {@code "sphere.categories"} for categories and
  *  {@code "sphere.product-types"} for product types.</p>
  *  <p>The grandchild loggers refer to the action. {@code "sphere.categories.requests"} refers to
- *  performing requests per HTTPS to commercetools for categories, {@code "sphere.categories.responses"} refers to the responses of the platform.
+ *  performing requests per HTTPS to Composable Commerce for categories, {@code "sphere.categories.responses"} refers to the responses from the API.
  *  {@code "sphere.categories.objects"} is for non HTTP API stuff like local object creation.
  *  </p>
  *
  *  The logger makes use of different log levels, so for example {@code "sphere.categories.responses"} logs on debug level the
- *  http response from the platform (abbreviated example):
+ *  http response from the API (abbreviated example):
  *
  *  <pre>10:59:18.623 [ForkJoinPool.commonPool-worker-3] DEBUG sphere.categories.responses - io.sphere.sdk.requests.HttpResponse@39984ae7[statusCode=200,responseBody={"offset":0,"count":4,"total":4,"results":[{"id":"2c41b33e-2d8e-415c-a4b7-f62628fa06e3","version":1,"name":{"en":"Hats"}, [...]</pre>
  *
- * {@code "sphere.categories.responses"} logs on trace level additional the formatted http response from the platform (abbreviated example):
+ * {@code "sphere.categories.responses"} logs on trace level additional the formatted http response from the API (abbreviated example):
  *
  * <pre>10:59:18.657 [ForkJoinPool.commonPool-worker-3] TRACE sphere.categories.responses - 200
  {

--- a/commercetools-test-lib/src/main/java/io/sphere/sdk/test/package-info.java
+++ b/commercetools-test-lib/src/main/java/io/sphere/sdk/test/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Provides utilities and fest assertions for unit and integration tests with the commercetools platform.
+ * Provides utilities and fest assertions for unit and integration tests with the Composable Commerce API.
  */
 package io.sphere.sdk.test;

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <artifactId>commercetools-jvm-sdk</artifactId>
     <packaging>pom</packaging>
     <version>2.9.0-SNAPSHOT</version>
-    <name>commercetools JVM SDK</name>
-    <description>Java bindings for the commercetools platform
+    <name>Composable Commerce JVM SDK</name>
+    <description>Java bindings for the commercetools Composable Commerce API
 
     This SDK is announced to be deprecated latest by 31 December 2022, please follow more details on SDK deprecation plan https://docs.commercetools.com/api/releases/2021-08-31-announced-long-term-support-plan-for-commercetools-sdks. We recommend you to use our new SDK here https://docs.commercetools.com/sdk/jvm-sdk#java-sdk-v2.</description>
     <url>https://github.com/commercetools/commercetools-jvm-sdk</url>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -1,5 +1,5 @@
 <body>
-    commercetools platform JVM SDK.
+    commercetools Composable Commerce JVM SDK.
     <div class="pull-up">
         <h3 class="toc-ignore">Pages about the SDK</h3>
 


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests, as this is out of scope.

Closes #