### PR TITLE
refactor tokensupplier to use client default scopes if none are given

### DIFF
--- a/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensSupplierImpl.java
+++ b/commercetools-java-client-core/src/main/java/io/sphere/sdk/client/TokensSupplierImpl.java
@@ -97,11 +97,13 @@ final class TokensSupplierImpl extends AutoCloseableService implements TokensSup
         final String projectKey = config.getProjectKey();
         final Map<String, String> data = new HashMap<>();
         data.put("grant_type", isPasswordFlow() ? "password" : "client_credentials");
-        final String scopeValue = config.getRawScopes().stream()
-                //.map(scope -> format("%s:%s", scope, projectKey))
-                .collect(joining(" "));
+        if (!config.getRawScopes().isEmpty()) {
+            final String scopeValue = config.getRawScopes().stream()
+                                            //.map(scope -> format("%s:%s", scope, projectKey))
+                                            .collect(joining(" "));
 
-        data.put("scope", scopeValue);
+            data.put("scope", scopeValue);
+        }
         if (isPasswordFlow()) {
             data.put("username", username);
             data.put("password", password);

--- a/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
@@ -33,10 +33,9 @@ public class ApacheClientIntegrationTest extends IntegrationTest {
      * This Exception is caused by the fact that the client closes after trying api callback with invalid scope
      * **/
     @Test(expected = IllegalStateException.class )
-    @Ignore
     public void stopRetriesOnInvalidConfig() throws Exception{
         final SphereClientConfig clientConfig = getSphereClientConfig();
-        final SphereClientConfig badConfig = SphereClientConfig.of(clientConfig.getProjectKey()+"LL",clientConfig.getClientId(),clientConfig.getClientSecret() ,clientConfig.getAuthUrl() ,clientConfig.getApiUrl()  );
+        final SphereClientConfig badConfig = SphereClientConfig.of(clientConfig.getProjectKey()+"LL",clientConfig.getClientId(),clientConfig.getClientSecret() ,clientConfig.getAuthUrl() ,clientConfig.getApiUrl(), clientConfig.getScopes());
         final HttpClient httpClient = newHttpClient();
         final SphereAccessTokenSupplier tokenSupplier = SphereAccessTokenSupplier.ofAutoRefresh(badConfig, httpClient, false);
         final SphereClient underlying = SphereClient.of(badConfig, httpClient, tokenSupplier);

--- a/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/client/ApacheClientIntegrationTest.java
@@ -7,6 +7,7 @@ import io.sphere.sdk.projects.queries.ProjectGet;
 import io.sphere.sdk.test.IntegrationTest;
 import io.sphere.sdk.test.SphereTestUtils;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,7 @@ public class ApacheClientIntegrationTest extends IntegrationTest {
      * This Exception is caused by the fact that the client closes after trying api callback with invalid scope
      * **/
     @Test(expected = IllegalStateException.class )
+    @Ignore
     public void stopRetriesOnInvalidConfig() throws Exception{
         final SphereClientConfig clientConfig = getSphereClientConfig();
         final SphereClientConfig badConfig = SphereClientConfig.of(clientConfig.getProjectKey()+"LL",clientConfig.getClientId(),clientConfig.getClientSecret() ,clientConfig.getAuthUrl() ,clientConfig.getApiUrl()  );

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
@@ -53,11 +53,11 @@ public final class SphereClientConfig extends Base implements SphereAuthConfig, 
     }
 
     public static SphereClientConfig of(final String projectKey, final String clientId, final String clientSecret, final String authUrl, final String apiUrl) {
-        return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, ClientPackage.DEFAULT_SCOPES, CorrelationIdGenerator.of(projectKey));
+        return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, new ArrayList<>(), CorrelationIdGenerator.of(projectKey));
     }
 
     public static SphereClientConfig of(final String projectKey, final String clientId, final String clientSecret, final String authUrl, final String apiUrl, final CorrelationIdGenerator correlationIdGenerator) {
-        return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, ClientPackage.DEFAULT_SCOPES, correlationIdGenerator);
+        return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, new ArrayList<>(), correlationIdGenerator);
     }
 
     @Override

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfig.java
@@ -60,6 +60,10 @@ public final class SphereClientConfig extends Base implements SphereAuthConfig, 
         return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, new ArrayList<>(), correlationIdGenerator);
     }
 
+    public static SphereClientConfig of(final String projectKey, final String clientId, final String clientSecret, final String authUrl, final String apiUrl, final List<String> scopes) {
+        return new SphereClientConfig(projectKey, clientId, clientSecret, authUrl, apiUrl, scopes, CorrelationIdGenerator.of(projectKey));
+    }
+
     @Override
     public String getApiUrl() {
         return apiUrl;

--- a/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfigUtils.java
+++ b/commercetools-sdk-base/src/main/java/io/sphere/sdk/client/SphereClientConfigUtils.java
@@ -84,7 +84,7 @@ final class SphereClientConfigUtils {
 
     private static List<SphereScope> scopesAsCommaSeparatedStringsToList(final String scopesAsString) {
         return isEmpty(scopesAsString)
-                    ? ClientPackage.DEFAULT_PROJECT_SCOPES
+                    ? new ArrayList<>()
                     : Arrays.stream(scopesAsString.split(","))
                     .map(SphereProjectScope::ofScopeString)
                     .collect(Collectors.toList());


### PR DESCRIPTION
# Description

Closes #

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone
- [ ] Update Composable Commerce API reference