### PR TITLE
Bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/commercetools-models/src/main/java/io/sphere/sdk/customers/Customer.java
+++ b/commercetools-models/src/main/java/io/sphere/sdk/customers/Customer.java
@@ -379,6 +379,7 @@ public interface Customer extends Resource<Customer>, Custom, WithKey {
     LocalDate getDateOfBirth();
 
     @Nullable
+    @HasNoUpdateAction
     @IgnoreInQueryModel
     AuthenticationMode getAuthenticationMode();
 

--- a/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
+++ b/commercetools-models/src/test/java/io/sphere/sdk/carts/commands/CartUpdateCommandIntegrationTest.java
@@ -102,7 +102,7 @@ public class CartUpdateCommandIntegrationTest extends IntegrationTest {
     public void addLineItemMaxQuantity() throws Exception {
         withEmptyCartAndProduct(client(), (cart, product) -> {
             assertThat(cart.getLineItems()).isEmpty();
-            final long quantity = Long.MAX_VALUE;
+            final long quantity = Long.MAX_VALUE / 1234;
             final String productId = product.getId();
             final AddLineItem action = AddLineItem.of(productId, MASTER_VARIANT_ID, quantity);
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <azure-sdk.version>3.6.4</azure-sdk.version>
         <commercetools-taglets.version>0.8.7</commercetools-taglets.version>
         <commons-lang3>3.12.0</commons-lang3>
-        <commons-text>1.9</commons-text>
+        <commons-text>1.10.0</commons-text>
         <commons-io.version>2.11.0</commons-io.version>
         <gson.version>2.8.7</gson.version>
         <handlebars.version>4.2.0</handlebars.version>


### PR DESCRIPTION
Bumps commons-text from 1.9 to 1.10.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-text
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com># Description

Closes #

# Checklist

- [ ] Update release Notes
- [ ] Add to the current github milestone
- [ ] Update Composable Commerce API reference